### PR TITLE
Prevent unintended null defaults in Stitch code generation

### DIFF
--- a/gradle-plugin-api/src/main/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/gradle-plugin-api/src/main/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -26,24 +26,24 @@ package dev.teogor.stitch.api
  * - Set the base package name for generated code or artifacts.
  */
 interface StitchExtension {
-    /**
-     * Enables or disables the generation of documentation.
-     *
-     * Set to `true` to generate documentation, `false` to disable it.
-     */
-    var addDocumentation: Boolean
+  /**
+   * Enables or disables the generation of documentation.
+   *
+   * Set to `true` to generate documentation, `false` to disable it.
+   */
+  var addDocumentation: Boolean
 
-    /**
-     * Enables or disables the generation of operations.
-     *
-     * Set to `true` to generate operations, `false` to disable it.
-     */
-    var generateOperations: Boolean
+  /**
+   * Enables or disables the generation of operations.
+   *
+   * Set to `true` to generate operations, `false` to disable it.
+   */
+  var generateOperations: Boolean
 
-    /**
-     * Specifies the base package name for generated code or artifacts.
-     *
-     * Ensure this matches your project's package structure.
-     */
-    var generatedPackageName: String
+  /**
+   * Specifies the base package name for generated code or artifacts.
+   *
+   * Ensure this matches your project's package structure.
+   */
+  var generatedPackageName: String
 }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -10,9 +10,19 @@ public final class dev/teogor/stitch/Plugin : org/gradle/api/Plugin {
 	public fun apply (Lorg/gradle/api/Project;)V
 }
 
-public final class dev/teogor/stitch/Plugin$apply$1$1$1$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+public final class dev/teogor/stitch/Plugin$apply$1$1$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public final synthetic fun execute (Ljava/lang/Object;)V
+}
+
+public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/api/StitchExtension {
+	public fun <init> ()V
+	public fun getAddDocumentation ()Z
+	public fun getGenerateOperations ()Z
+	public fun getGeneratedPackageName ()Ljava/lang/String;
+	public fun setAddDocumentation (Z)V
+	public fun setGenerateOperations (Z)V
+	public fun setGeneratedPackageName (Ljava/lang/String;)V
 }
 
 public final class dev/teogor/stitch/StitchSchemaArgProvider : org/gradle/process/CommandLineArgumentProvider {

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/Plugin.kt
@@ -23,22 +23,33 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 
+/**
+ * A Plugin for applying Stitch functionalities to your project.
+ *
+ * This plugin configures Ksp to generate code based on your project's Stitch schema.
+ * You can customize generation behavior through the provided [StitchExtension].
+ *
+ * @see StitchExtension interface for configuration options.
+ */
 class Plugin : Plugin<Project> {
-    override fun apply(target: Project) {
-        with(target) {
-            val stitchExtension = extensions.create<StitchExtension>(
-                name = "stitch",
-            )
+  override fun apply(target: Project) {
+    with(target) {
+      // Create a named extension instance for configuration
+      val extension = extensions.create(
+        publicType = StitchExtension::class,
+        name = "stitch",
+        instanceType = StitchExtensionImpl::class,
+      )
 
-            with(target) {
-                pluginManager.apply("com.google.devtools.ksp")
+      // Apply the KSP plugin
+      pluginManager.apply("com.google.devtools.ksp")
 
-                afterEvaluate {
-                    extensions.configure<KspExtension> {
-                        arg(StitchSchemaArgProvider.from(stitchExtension))
-                    }
-                }
-            }
+      // Configure KSP extension after project evaluation
+      afterEvaluate {
+        extensions.configure<KspExtension> {
+          arg(StitchSchemaArgProvider.from(extension))
         }
+      }
     }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch
+
+import dev.teogor.stitch.api.StitchExtension
+
+/**
+ * Base implementation for the [StitchExtension] interface.
+ *
+ * This abstract class provides default values for all properties of the
+ * [StitchExtension] interface.
+ *
+ * You can extend this class and override properties to customize the behavior
+ * of Stitch code generation.
+ *
+ * @see StitchExtension
+ */
+abstract class StitchExtensionImpl : StitchExtension {
+
+  /**
+   * Controls whether to generate documentation comments in the generated code.
+   *
+   * By default, this is set to `true`.
+   */
+  override var addDocumentation: Boolean = true
+
+  /**
+   * Controls whether to generate operation functions for your Stitch schema.
+   *
+   * By default, this is set to `true`.
+   */
+  override var generateOperations: Boolean = true
+
+  /**
+   * Specifies the base package name for generated code or artifacts.
+   *
+   * By default, this is an empty string, meaning the generated code will be
+   * placed in the root package.
+   */
+  override var generatedPackageName: String = ""
+}

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -20,22 +20,22 @@ import dev.teogor.stitch.api.StitchExtension
 import org.gradle.process.CommandLineArgumentProvider
 
 class StitchSchemaArgProvider(
-    private val addDocumentation: Boolean,
-    private val generateOperations: Boolean,
-    private val generatedPackageName: String,
+  private val addDocumentation: Boolean,
+  private val generateOperations: Boolean,
+  private val generatedPackageName: String,
 ) : CommandLineArgumentProvider {
 
-    override fun asArguments() = listOf(
-        "stitch.addDocumentation=$addDocumentation",
-        "stitch.generateOperations=$generateOperations",
-        "stitch.generatedPackageName=$generatedPackageName",
-    )
+  override fun asArguments() = listOf(
+    "stitch.addDocumentation=$addDocumentation",
+    "stitch.generateOperations=$generateOperations",
+    "stitch.generatedPackageName=$generatedPackageName",
+  )
 
-    companion object {
-        fun from(stitchExtension: StitchExtension) = StitchSchemaArgProvider(
-            addDocumentation = stitchExtension.addDocumentation,
-            generateOperations = stitchExtension.generateOperations,
-            generatedPackageName = stitchExtension.generatedPackageName,
-        )
-    }
+  companion object {
+    fun from(stitchExtension: StitchExtension) = StitchSchemaArgProvider(
+      addDocumentation = stitchExtension.addDocumentation,
+      generateOperations = stitchExtension.generateOperations,
+      generatedPackageName = stitchExtension.generatedPackageName,
+    )
+  }
 }


### PR DESCRIPTION
**Issue:**

The previous implementation of `StitchExtensionImpl` used `null` for default values, potentially leading to unexpected behavior during Stitch code generation.

**Fix:**

This pull request addresses this issue by explicitly setting sensible default values for all properties in `StitchExtensionImpl`:

* `addDocumentation`: Set to `true` to include documentation comments by default.
* `generateOperations`: Set to `true` to generate operation functions by default.
* `generatedPackageName`: Set to an empty string (`""`) to use the root package by default.

**Changes:**

* Updated `StitchExtensionImpl` constructor to assign these default values explicitly.