### PR TITLE
Migrate to Room 3.0.0-alpha06

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,8 +62,8 @@ dependencies {
   implementation(libs.androidx.material3)
 
   implementation(libs.room.runtime)
-  implementation(libs.room.ktx)
   ksp(libs.room.compiler)
+  implementation(libs.sqlite.bundled)
 
   implementation(libs.hilt.android)
   ksp(libs.hilt.compiler)

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/AppDatabase.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/AppDatabase.kt
@@ -17,10 +17,11 @@
 package com.zeoowl.beatifyd.core.data
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.room.TypeConverters
+import androidx.room3.Database
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
+import androidx.room3.TypeConverters
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.zeoowl.beatifyd.core.data.dao.BlackListStoreDao
 import com.zeoowl.beatifyd.core.data.dao.HistoryDao
 import com.zeoowl.beatifyd.core.data.dao.LyricsDao
@@ -57,11 +58,11 @@ abstract class AppDatabase : RoomDatabase() {
 
     fun getInstance(context: Context): AppDatabase {
       if (INSTANCE == null) {
-        INSTANCE = Room.databaseBuilder(
-          context,
-          AppDatabase::class.java,
-          "main_database",
-        ).build()
+        INSTANCE = Room.databaseBuilder<AppDatabase>(
+          context = context,
+          name = "main_database",
+        ).setDriver(BundledSQLiteDriver())
+          .build()
       }
 
       return INSTANCE as AppDatabase

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/BlackListStoreDao.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/BlackListStoreDao.kt
@@ -16,11 +16,11 @@
 
 package com.zeoowl.beatifyd.core.data.dao
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
 import com.zeoowl.beatifyd.core.data.model.BlackListStoreEntity
 import dev.teogor.stitch.ExplicitEntities
 

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/HistoryDao.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/HistoryDao.kt
@@ -16,9 +16,9 @@
 
 package com.zeoowl.beatifyd.core.data.dao
 
-import androidx.room.Dao
-import androidx.room.Query
-import androidx.room.Upsert
+import androidx.room3.Dao
+import androidx.room3.Query
+import androidx.room3.Upsert
 import com.zeoowl.beatifyd.core.data.model.History
 import dev.teogor.stitch.ExplicitEntities
 import kotlinx.coroutines.flow.Flow
@@ -38,7 +38,7 @@ interface HistoryDao {
   suspend fun upsertSongInHistory(history: History)
 
   @Query("DELETE FROM History WHERE id= :songId")
-  fun deleteSongInHistory(songId: Long)
+  suspend fun deleteSongInHistory(songId: Long)
 
   @Query("SELECT * FROM History ORDER BY time_played DESC LIMIT $HISTORY_LIMIT")
   fun historySongs(): Flow<List<History>>

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/LyricsDao.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/LyricsDao.kt
@@ -16,11 +16,11 @@
 
 package com.zeoowl.beatifyd.core.data.dao
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.Query
+import androidx.room3.Update
 import com.zeoowl.beatifyd.core.data.model.Lyrics
 
 @Dao

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/PlaylistDao.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/dao/PlaylistDao.kt
@@ -16,13 +16,13 @@
 
 package com.zeoowl.beatifyd.core.data.dao
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.RewriteQueriesToDropUnusedColumns
-import androidx.room.Transaction
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.RewriteQueriesToDropUnusedColumns
+import androidx.room3.Transaction
 import com.zeoowl.beatifyd.core.data.model.Playlist
 import com.zeoowl.beatifyd.core.data.model.PlaylistWithSongs
 import com.zeoowl.beatifyd.core.data.model.Song
@@ -43,7 +43,7 @@ interface PlaylistDao {
   suspend fun renamePlaylist(playlistId: Long, name: String)
 
   @Query("SELECT * FROM Playlist WHERE playlist_name = :name")
-  fun playlist(name: String): List<Playlist>
+  suspend fun playlist(name: String): List<Playlist>
 
   @Query("SELECT * FROM Playlist")
   suspend fun playlists(): List<Playlist>
@@ -87,7 +87,7 @@ interface PlaylistDao {
   fun favoritesSongsLiveData(playlistName: String): Flow<List<Song>>
 
   @Query("SELECT * FROM Song WHERE playlist_creator_id= :playlistId")
-  fun favoritesSongs(playlistId: Long): List<Song>
+  suspend fun favoritesSongs(playlistId: Long): List<Song>
 
   @Query("SELECT EXISTS(SELECT * FROM Playlist WHERE playlist_id = :playlistId)")
   fun checkPlaylistExists(playlistId: Long): Flow<Boolean>

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/BlackListStoreEntity.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/BlackListStoreEntity.kt
@@ -16,8 +16,8 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity
 data class BlackListStoreEntity(

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/History.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/History.kt
@@ -16,9 +16,9 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity
 data class History(

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Lyrics.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Lyrics.kt
@@ -16,8 +16,8 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity
 data class Lyrics(

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Playlist.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Playlist.kt
@@ -16,9 +16,9 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 
 @Entity
 class Playlist(

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/PlaylistWithSongs.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/PlaylistWithSongs.kt
@@ -16,14 +16,14 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.Embedded
-import androidx.room.Relation
+import androidx.room3.Embedded
+import androidx.room3.Relation
 
 data class PlaylistWithSongs(
   @Embedded val playlist: Playlist,
   @Relation(
-    parentColumn = "playlist_id",
-    entityColumn = "playlist_creator_id",
+    parentColumns = ["playlist_id"],
+    entityColumns = ["playlist_creator_id"],
   )
   val songs: List<Song>,
 )

--- a/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Song.kt
+++ b/app/src/main/kotlin/com/zeoowl/beatifyd/core/data/model/Song.kt
@@ -16,10 +16,10 @@
 
 package com.zeoowl.beatifyd.core.data.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.Index
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.Index
+import androidx.room3.PrimaryKey
 
 @Entity(
   indices = [

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/AppDatabase.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/AppDatabase.kt
@@ -17,10 +17,11 @@
 package dev.teogor.stitch.core.database
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
-import androidx.room.TypeConverters
+import androidx.room3.Database
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
+import androidx.room3.TypeConverters
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import dev.teogor.stitch.core.database.dao.SavedGameDao
 import dev.teogor.stitch.core.database.dao.TestingKindDao
 import dev.teogor.stitch.core.database.model.SavedGame
@@ -52,11 +53,11 @@ abstract class AppDatabase : RoomDatabase() {
 
     fun getInstance(context: Context): AppDatabase {
       if (INSTANCE == null) {
-        INSTANCE = Room.databaseBuilder(
-          context,
-          AppDatabase::class.java,
-          "main_database",
-        ).build()
+        INSTANCE = Room.databaseBuilder<AppDatabase>(
+          context = context,
+          name = "main_database",
+        ).setDriver(BundledSQLiteDriver())
+          .build()
       }
 
       return INSTANCE as AppDatabase

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/dao/SavedGameDao.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/dao/SavedGameDao.kt
@@ -16,12 +16,12 @@
 
 package dev.teogor.stitch.core.database.dao
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.Update
 import dev.teogor.stitch.RawOperation
 import dev.teogor.stitch.core.database.model.SavedGame
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/dao/TestingKindDao.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/dao/TestingKindDao.kt
@@ -16,12 +16,12 @@
 
 package dev.teogor.stitch.core.database.dao
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room3.Dao
+import androidx.room3.Delete
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.Update
 import dev.teogor.stitch.core.database.model.SavedGame
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/model/SavedGame.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/model/SavedGame.kt
@@ -16,9 +16,9 @@
 
 package dev.teogor.stitch.core.database.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 import java.time.Duration
 import java.time.ZonedDateTime
 

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/model/TestingKind.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/model/TestingKind.kt
@@ -16,9 +16,9 @@
 
 package dev.teogor.stitch.core.database.model
 
-import androidx.room.ColumnInfo
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 import java.time.Duration
 import java.time.ZonedDateTime
 

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/util/Converters.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/util/Converters.kt
@@ -16,7 +16,7 @@
 
 package dev.teogor.stitch.core.database.util
 
-import androidx.room.TypeConverter
+import androidx.room3.TypeConverter
 import dev.teogor.stitch.core.database.model.Difficulty
 import dev.teogor.stitch.core.database.model.GameType
 import dev.teogor.stitch.core.database.model.SudokuEventType

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/util/DurationConverter.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/util/DurationConverter.kt
@@ -16,7 +16,7 @@
 
 package dev.teogor.stitch.core.database.util
 
-import androidx.room.TypeConverter
+import androidx.room3.TypeConverter
 import java.time.Duration
 
 /**

--- a/app/src/main/kotlin/dev/teogor/stitch/core/database/util/ZonedDateTimeConverter.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/database/util/ZonedDateTimeConverter.kt
@@ -16,7 +16,7 @@
 
 package dev.teogor.stitch.core.database.util
 
-import androidx.room.TypeConverter
+import androidx.room3.TypeConverter
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,8 @@ espresso-core = "3.6.1"
 lifecycle = "2.11.0-rc01"
 activity-compose = "1.13.0"
 compose-bom = "2025.02.00"
-room = "2.7.0-alpha13"
+room = "3.0.0-alpha06"
+sqlite = "2.7.0-alpha06"
 hilt = "2.59.2"
 hiltExt = "1.2.0"
 kotlin-poet = "2.3.0"
@@ -45,10 +46,10 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-room-common = { group = "androidx.room", name = "room-common", version.ref = "room" }
-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-common = { group = "androidx.room3", name = "room3-common", version.ref = "room" }
+room-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "room" }
+room-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "room" }
+sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqlite" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }

--- a/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/Processor.kt
+++ b/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/Processor.kt
@@ -16,9 +16,9 @@
 
 package dev.teogor.stitch.ksp.processors
 
-import androidx.room.Dao
-import androidx.room.Database
-import androidx.room.Entity
+import androidx.room3.Dao
+import androidx.room3.Database
+import androidx.room3.Entity
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.getAnnotationsByType


### PR DESCRIPTION
This PR migrates the project from Room 2.7.0-alpha13 to Room 3.0.0-alpha06.

Key changes:
- Updated dependencies to `androidx.room3` artifacts.
- Migrated all imports and annotations to the `androidx.room3` namespace.
- Integrated `BundledSQLiteDriver` in `AppDatabase`.
- Refactored DAO methods to be `suspend` where necessary.
- Updated `@Relation` annotations to use `parentColumns` and `entityColumns`.
- Updated internal KSP processor for Room 3 compatibility.