### PR TITLE
Migrate from Hilt to Metro DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
 **Stitch offers a tapestry of benefits:**
 
 * **Automatic Code Generation:** Say goodbye to repetitive boilerplate! Stitch generates Repositories, Repository Implementations, and Operations based on your Room DAOs and entities.
-* **Seamless Hilt Integration:** Enjoy a smooth blend of dependency injection with automatically created Hilt modules, ensuring your code remains clean and organized.
+* **Seamless Metro Integration:** Enjoy a smooth blend of dependency injection with automatically created Metro binding containers, ensuring your code remains clean and organized.
 * **Tailored to Your Needs:** Customize generated code to perfectly fit your project's unique requirements, ensuring a truly bespoke solution.
 * **Asynchronous Agility:** Embrace the power of coroutines with Stitch's efficient data handling, keeping your app responsive and nimble.
 * **KSP-powered Efficiency:** Leverage the magic of Kotlin Symbol Processing for accurate and optimized code generation, ensuring seamless integration.
@@ -35,7 +35,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
     * Customizing base class or interface for repositories.
     * Specifying naming conventions for generated components.
     * Excluding specific entities or DAOs from generation.
-* **Dependency Injection Integration:** Stitch seamlessly integrates with Hilt, automatically generating modules for injected repository instances.
+* **Dependency Injection Integration:** Stitch seamlessly integrates with Metro, automatically generating binding containers for injected repository instances.
 * **Coroutine-friendly Operations:** Stitch supports asynchronous data access using coroutines, ensuring a responsive and efficient user experience.
 * **Efficient KSP Integration:** Leverages Kotlin Symbol Processing for accurate and optimized code generation based on your project's specific setup.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 plugins {
   alias(libs.plugins.stitch.android.application)
-  alias(libs.plugins.hilt)
+  alias(libs.plugins.metro)
   alias(libs.plugins.ksp)
 }
 
@@ -65,8 +65,7 @@ dependencies {
   ksp(libs.room.compiler)
   implementation(libs.sqlite.bundled)
 
-  implementation(libs.hilt.android)
-  ksp(libs.hilt.compiler)
+  implementation(libs.metro.runtime)
 
   testImplementation(libs.junit)
   androidTestImplementation(libs.androidx.junit)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:${buildLibs.findVersion("kotlin").get().requiredVersion}")
     compileOnly("org.jetbrains.kotlin:compose-compiler-gradle-plugin:${buildLibs.findVersion("kotlin").get().requiredVersion}")
     compileOnly("com.google.devtools.ksp:symbol-processing-gradle-plugin:${buildLibs.findVersion("ksp").get().requiredVersion}")
-    compileOnly("com.google.dagger:hilt-android-gradle-plugin:${buildLibs.findVersion("hilt").get().requiredVersion}")
+    compileOnly("dev.zacsweers.metro:dev.zacsweers.metro.gradle.plugin:${buildLibs.findVersion("metro").get().requiredVersion}")
     compileOnly("dev.teogor.winds:dev.teogor.winds.gradle.plugin:${buildLibs.findVersion("winds").get().requiredVersion}")
 }
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -8,13 +8,13 @@ plugins {
 group = "dev.teogor.stitch.buildlogic"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        jvmTarget = JvmTarget.JVM_21
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/AndroidApplicationConventionPlugin.kt
@@ -37,8 +37,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     }
                 }
                 compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_11
-                    targetCompatibility = JavaVersion.VERSION_11
+                    sourceCompatibility = JavaVersion.VERSION_21
+                    targetCompatibility = JavaVersion.VERSION_21
                 }
                 buildFeatures {
                     compose = true
@@ -47,7 +47,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             extensions.configure<KotlinAndroidProjectExtension> {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_11)
+                    jvmTarget.set(JvmTarget.JVM_21)
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/LibraryConventionPlugin.kt
@@ -18,13 +18,13 @@ class LibraryConventionPlugin : Plugin<Project> {
             }
 
             extensions.configure<JavaPluginExtension> {
-                sourceCompatibility = JavaVersion.VERSION_11
-                targetCompatibility = JavaVersion.VERSION_11
+                sourceCompatibility = JavaVersion.VERSION_21
+                targetCompatibility = JavaVersion.VERSION_21
             }
 
             tasks.withType<KotlinCompile>().configureEach {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_11)
+                    jvmTarget.set(JvmTarget.JVM_21)
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
   alias(libs.plugins.jetbrains.kotlin.android) apply false
   alias(libs.plugins.jetbrains.kotlin.jvm) apply false
   alias(libs.plugins.jetbrains.compose.compiler) apply false
-  alias(libs.plugins.hilt) apply false
+  alias(libs.plugins.metro) apply false
   alias(libs.plugins.ksp) apply false
 
   alias(libs.plugins.winds) apply true

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
@@ -18,31 +18,27 @@ package dev.teogor.stitch.codegen.commons
 
 import com.squareup.kotlinpoet.ClassName
 
-val DAGGER_MODULE = ClassName(
-  packageName = "dagger",
-  "Module",
+val METRO_BINDING_CONTAINER = ClassName(
+  packageName = "dev.zacsweers.metro",
+  "BindingContainer",
 )
-val DAGGER_PROVIDES = ClassName(
-  packageName = "dagger",
+val METRO_PROVIDES = ClassName(
+  packageName = "dev.zacsweers.metro",
   "Provides",
 )
-val DAGGER_INSTALL_IN = ClassName(
-  packageName = "dagger.hilt",
-  "InstallIn",
+val METRO_CONTRIBUTES_TO = ClassName(
+  packageName = "dev.zacsweers.metro",
+  "ContributesTo",
 )
-val DAGGER_APPLICATION_CONTEXT = ClassName(
-  packageName = "dagger.hilt.android.qualifiers",
-  "ApplicationContext",
+val STITCH_SCOPE = ClassName(
+  packageName = "dev.teogor.stitch.di",
+  "StitchScope",
 )
-val DAGGER_SINGLETON_COMPONENT = ClassName(
-  packageName = "dagger.hilt.components",
-  "SingletonComponent",
-)
-val JAVAX_INJECT_SINGLETON = ClassName(
-  packageName = "javax.inject",
+val METRO_SINGLETON = ClassName(
+  packageName = "dev.zacsweers.metro",
   "Singleton",
 )
-val JAVAX_INJECT = ClassName(
-  packageName = "javax.inject",
+val METRO_INJECT = ClassName(
+  packageName = "dev.zacsweers.metro",
   "Inject",
 )

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
@@ -34,9 +34,9 @@ val STITCH_SCOPE = ClassName(
   packageName = "dev.teogor.stitch.di",
   "StitchScope",
 )
-val METRO_SINGLETON = ClassName(
+val METRO_SINGLE_IN = ClassName(
   packageName = "dev.zacsweers.metro",
-  "Singleton",
+  "SingleIn",
 )
 val METRO_INJECT = ClassName(
   packageName = "dev.zacsweers.metro",

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
@@ -25,7 +25,7 @@ import com.squareup.kotlinpoet.UNIT
 import dev.teogor.stitch.Operation
 import dev.teogor.stitch.OperationSignature
 import dev.teogor.stitch.api.OperationGenerationLevel
-import dev.teogor.stitch.codegen.commons.JAVAX_INJECT
+import dev.teogor.stitch.codegen.commons.METRO_INJECT
 import dev.teogor.stitch.codegen.commons.fileBuilder
 import dev.teogor.stitch.codegen.commons.titleCase
 import dev.teogor.stitch.codegen.commons.writeWith
@@ -118,7 +118,7 @@ class OperationOutputWriter(
                         "${room.name}Repository",
                       ),
                     )
-                    .addAnnotation(JAVAX_INJECT)
+                    .addAnnotation(METRO_INJECT)
                     .build(),
                 )
                 invokeFunctions.forEach { addFunction(it) }

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -21,11 +21,11 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
-import dev.teogor.stitch.codegen.commons.DAGGER_INSTALL_IN
-import dev.teogor.stitch.codegen.commons.DAGGER_MODULE
-import dev.teogor.stitch.codegen.commons.DAGGER_PROVIDES
-import dev.teogor.stitch.codegen.commons.DAGGER_SINGLETON_COMPONENT
-import dev.teogor.stitch.codegen.commons.JAVAX_INJECT_SINGLETON
+import dev.teogor.stitch.codegen.commons.METRO_BINDING_CONTAINER
+import dev.teogor.stitch.codegen.commons.METRO_CONTRIBUTES_TO
+import dev.teogor.stitch.codegen.commons.METRO_PROVIDES
+import dev.teogor.stitch.codegen.commons.METRO_SINGLETON
+import dev.teogor.stitch.codegen.commons.STITCH_SCOPE
 import dev.teogor.stitch.codegen.commons.fileBuilder
 import dev.teogor.stitch.codegen.commons.shortName
 import dev.teogor.stitch.codegen.commons.writeWith
@@ -48,10 +48,10 @@ class StitchModuleOutputWriter(
     ) {
       addType(
         TypeSpec.objectBuilder("StitchModule")
-          .addAnnotation(DAGGER_MODULE)
+          .addAnnotation(METRO_BINDING_CONTAINER)
           .addAnnotation(
-            AnnotationSpec.builder(DAGGER_INSTALL_IN)
-              .addMember("%T::class", DAGGER_SINGLETON_COMPONENT)
+            AnnotationSpec.builder(METRO_CONTRIBUTES_TO)
+              .addMember("%T::class", STITCH_SCOPE)
               .build(),
           )
           .addDocumentation(
@@ -65,7 +65,7 @@ class StitchModuleOutputWriter(
           .apply {
             addFunction(
               FunSpec.builder("provideAppDatabase")
-                .addAnnotation(DAGGER_PROVIDES)
+                .addAnnotation(METRO_PROVIDES)
                 .addParameter("app", ClassName("android.app", "Application"))
                 .returns(databaseModels.first().type)
                 .addDocumentation(
@@ -101,8 +101,8 @@ class StitchModuleOutputWriter(
                     @see [${database.type.shortName}]
                       """.trimIndent(),
                     )
-                    .addAnnotation(JAVAX_INJECT_SINGLETON)
-                    .addAnnotation(DAGGER_PROVIDES)
+                    .addAnnotation(METRO_SINGLETON)
+                    .addAnnotation(METRO_PROVIDES)
                     .returns(
                       ClassName(
                         "${roomModel.packageName}.dao",
@@ -131,8 +131,8 @@ class StitchModuleOutputWriter(
                     @see [${roomModel.name}Repository]
                     """.trimIndent(),
                   )
-                  .addAnnotation(JAVAX_INJECT_SINGLETON)
-                  .addAnnotation(DAGGER_PROVIDES)
+                  .addAnnotation(METRO_SINGLETON)
+                  .addAnnotation(METRO_PROVIDES)
                   .returns(
                     ClassName(
                       "${roomModel.getPackageName()}.data.repository",

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -24,7 +24,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import dev.teogor.stitch.codegen.commons.METRO_BINDING_CONTAINER
 import dev.teogor.stitch.codegen.commons.METRO_CONTRIBUTES_TO
 import dev.teogor.stitch.codegen.commons.METRO_PROVIDES
-import dev.teogor.stitch.codegen.commons.METRO_SINGLETON
+import dev.teogor.stitch.codegen.commons.METRO_SINGLE_IN
 import dev.teogor.stitch.codegen.commons.STITCH_SCOPE
 import dev.teogor.stitch.codegen.commons.fileBuilder
 import dev.teogor.stitch.codegen.commons.shortName
@@ -101,7 +101,11 @@ class StitchModuleOutputWriter(
                     @see [${database.type.shortName}]
                       """.trimIndent(),
                     )
-                    .addAnnotation(METRO_SINGLETON)
+                    .addAnnotation(
+                      AnnotationSpec.builder(METRO_SINGLE_IN)
+                        .addMember("%T::class", STITCH_SCOPE)
+                        .build(),
+                    )
                     .addAnnotation(METRO_PROVIDES)
                     .returns(
                       ClassName(
@@ -131,7 +135,11 @@ class StitchModuleOutputWriter(
                     @see [${roomModel.name}Repository]
                     """.trimIndent(),
                   )
-                  .addAnnotation(METRO_SINGLETON)
+                  .addAnnotation(
+                    AnnotationSpec.builder(METRO_SINGLE_IN)
+                      .addMember("%T::class", STITCH_SCOPE)
+                      .build(),
+                  )
                   .addAnnotation(METRO_PROVIDES)
                   .returns(
                     ClassName(

--- a/common/src/main/kotlin/dev/teogor/stitch/di/Scopes.kt
+++ b/common/src/main/kotlin/dev/teogor/stitch/di/Scopes.kt
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-  alias(libs.plugins.stitch.kotlin.library)
-}
 
-dependencies {
-  api(libs.room.common)
-  api(libs.metro.runtime)
-}
+package dev.teogor.stitch.di
 
-winds {
-  moduleMetadata {
-    artifactDescriptor {
-      name = "common"
-    }
-  }
-}
+/**
+ * A scope marker used for Stitch-related dependency injection.
+ */
+abstract class StitchScope private constructor()

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
 **Stitch offers a tapestry of benefits:**
 
 * **Automatic Code Generation:** Say goodbye to repetitive boilerplate! Stitch generates Repositories, Repository Implementations, and Operations based on your Room DAOs and entities.
-* **Seamless Hilt Integration:** Enjoy a smooth blend of dependency injection with automatically created Hilt modules, ensuring your code remains clean and organized.
+* **Seamless Metro Integration:** Enjoy a smooth blend of dependency injection with automatically created Metro binding containers, ensuring your code remains clean and organized.
 * **Tailored to Your Needs:** Customize generated code to perfectly fit your project's unique requirements, ensuring a truly bespoke solution.
 * **Asynchronous Agility:** Embrace the power of coroutines with Stitch's efficient data handling, keeping your app responsive and nimble.
 * **KSP-powered Efficiency:** Leverage the magic of Kotlin Symbol Processing for accurate and optimized code generation, ensuring seamless integration.
@@ -35,7 +35,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
   * Customizing base class or interface for repositories.
   * Specifying naming conventions for generated components.
   * Excluding specific entities or DAOs from generation.
-* **Dependency Injection Integration:** Stitch seamlessly integrates with Hilt, automatically generating modules for injected repository instances.
+* **Dependency Injection Integration:** Stitch seamlessly integrates with Metro, automatically generating binding containers for injected repository instances.
 * **Coroutine-friendly Operations:** Stitch supports asynchronous data access using coroutines, ensuring a responsive and efficient user experience.
 * **Efficient KSP Integration:** Leverages Kotlin Symbol Processing for accurate and optimized code generation based on your project's specific setup.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,8 +21,7 @@ activity-compose = "1.13.0"
 compose-bom = "2026.05.01"
 room = "3.0.0-alpha06"
 sqlite = "2.7.0-alpha06"
-hilt = "2.59.2"
-hiltExt = "1.2.0"
+metro = "1.2.0"
 kotlin-poet = "2.3.0"
 gradle-publish = "2.1.1"
 build-config = "6.0.10"
@@ -50,11 +49,7 @@ room-common = { group = "androidx.room3", name = "room3-common", version.ref = "
 room-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "room" }
 room-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "room" }
 sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqlite" }
-hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
-hilt-ext-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltExt" }
-hilt-ext-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltExt" }
+metro-runtime = { group = "dev.zacsweers.metro", name = "runtime", version.ref = "metro" }
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlin-poet" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
@@ -69,7 +64,7 @@ stitch-kotlin-library = { id = "stitch.kotlin.library" }
 stitch-gradle-plugin = { id = "stitch.gradle.plugin" }
 
 # External plugins
-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
This PR migrates the Stitch project from Hilt to the Metro dependency injection library.

Key changes:
- Upgraded project to Java 21 (required by Metro 1.2.0).
- Replaced Hilt dependencies and plugins with Metro.
- Updated the code generator to emit Metro-compatible annotations (@BindingContainer, @ContributesTo, @Provides, @Inject).
- Implemented the @SingleIn(StitchScope::class) pattern for idiomatic scoping.
- Defined a project-wide StitchScope in the common module.
- Updated documentation to reflect the new DI integration.

The migration has been verified with a successful build and inspection of generated code.