### PR TITLE
feat: allow opting out of metro integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
     * Customizing base class or interface for repositories.
     * Specifying naming conventions for generated components.
     * Excluding specific entities or DAOs from generation.
+    * **Opt-out of Metro:** Use Stitch without Metro by disabling it in your configuration.
 * **Dependency Injection Integration:** Stitch seamlessly integrates with Metro, automatically generating binding containers for injected repository instances.
 * **Coroutine-friendly Operations:** Stitch supports asynchronous data access using coroutines, ensuring a responsive and efficient user experience.
 * **Efficient KSP Integration:** Leverages Kotlin Symbol Processing for accurate and optimized code generation based on your project's specific setup.

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -23,4 +23,5 @@ data class CodeGenConfig(
   val enableOperationGeneration: Boolean,
   val generatedPackageName: String?,
   val operationGenerationLevel: OperationGenerationLevel,
+  val enableMetro: Boolean,
 )

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
@@ -118,7 +118,11 @@ class OperationOutputWriter(
                         "${room.name}Repository",
                       ),
                     )
-                    .addAnnotation(METRO_INJECT)
+                    .apply {
+                      if (codeGenConfig.enableMetro) {
+                        addAnnotation(METRO_INJECT)
+                      }
+                    }
                     .build(),
                 )
                 invokeFunctions.forEach { addFunction(it) }

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -41,6 +41,9 @@ class StitchModuleOutputWriter(
 ) : OutputWriter(codeGenConfig) {
 
   fun write(databaseModels: Sequence<DatabaseModel>, roomModels: List<RoomModel>) {
+    if (!codeGenConfig.enableMetro) {
+      return
+    }
     val packageName = roomModels.first().getPackageName()
     fileBuilder(
       packageName = "$packageName.di",

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
 
 dependencies {
   api(libs.room.common)
-  api(libs.metro.runtime)
+  compileOnly(libs.metro.runtime)
 }
 
 winds {

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
   * Customizing base class or interface for repositories.
   * Specifying naming conventions for generated components.
   * Excluding specific entities or DAOs from generation.
+  * **Opt-out of Metro:** Use Stitch without Metro by disabling it in your configuration.
 * **Dependency Injection Integration:** Stitch seamlessly integrates with Metro, automatically generating binding containers for injected repository instances.
 * **Coroutine-friendly Operations:** Stitch supports asynchronous data access using coroutines, ensuring a responsive and efficient user experience.
 * **Efficient KSP Integration:** Leverages Kotlin Symbol Processing for accurate and optimized code generation based on your project's specific setup.

--- a/gradle-plugin-api/src/main/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/gradle-plugin-api/src/main/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -79,4 +79,15 @@ interface StitchExtension {
    * @return The base package name for generated code.
    */
   var generatedPackageName: String
+
+  /**
+   * Controls whether to integrate with Metro for dependency injection.
+   *
+   * When enabled (default), Stitch will generate Metro-specific annotations and
+   * binding containers. If disabled, Stitch will generate vanilla code without
+   * Metro dependencies.
+   *
+   * @return `true` if Metro integration is enabled, `false` otherwise.
+   */
+  var enableMetro: Boolean
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -73,4 +73,11 @@ abstract class StitchExtensionImpl : StitchExtension {
    * placed in the root package.
    */
   override var generatedPackageName: String = ""
+
+  /**
+   * Controls whether to integrate with Metro for dependency injection.
+   *
+   * By default, this is set to `true`.
+   */
+  override var enableMetro: Boolean = true
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -25,6 +25,7 @@ class StitchSchemaArgProvider(
   private val enableOperationGeneration: Boolean,
   private val generatedPackageName: String,
   private val operationGenerationLevel: OperationGenerationLevel,
+  private val enableMetro: Boolean,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -32,6 +33,7 @@ class StitchSchemaArgProvider(
     "stitch.enableOperationGeneration=$enableOperationGeneration",
     "stitch.generatedPackageName=$generatedPackageName",
     "stitch.operationGenerationLevel=$operationGenerationLevel",
+    "stitch.enableMetro=$enableMetro",
   )
 
   companion object {
@@ -40,6 +42,7 @@ class StitchSchemaArgProvider(
       enableOperationGeneration = stitchExtension.enableOperationGeneration,
       generatedPackageName = stitchExtension.generatedPackageName,
       operationGenerationLevel = stitchExtension.operationGenerationLevel,
+      enableMetro = stitchExtension.enableMetro,
     )
   }
 }

--- a/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
+++ b/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
@@ -33,6 +33,7 @@ class ConfigParser(
     private const val ENABLE_OPERATION_GENERATION = "$PREFIX.enableOperationGeneration"
     private const val GENERATED_PACKAGE_NAME = "$PREFIX.generatedPackageName"
     private const val OPERATION_GENERATION_LEVEL = "$PREFIX.operationGenerationLevel"
+    private const val ENABLE_METRO = "$PREFIX.enableMetro"
   }
 
   fun parse(): CodeGenConfig {
@@ -40,12 +41,14 @@ class ConfigParser(
     val enableOperationGeneration = parseBoolean(ENABLE_OPERATION_GENERATION) ?: true
     val generatedPackageName = options[GENERATED_PACKAGE_NAME]?.trim()?.removeSuffix(".")
     val operationGenerationLevel = getOperationGenerationLevel()
+    val enableMetro = parseBoolean(ENABLE_METRO) ?: true
 
     return CodeGenConfig(
       addDocumentation = addDocumentation,
       enableOperationGeneration = enableOperationGeneration,
       generatedPackageName = generatedPackageName,
       operationGenerationLevel = operationGenerationLevel,
+      enableMetro = enableMetro,
     )
   }
 


### PR DESCRIPTION
This PR adds the capability to opt out of Metro integration by setting `enableMetro = false` in the `stitch` configuration block. It also refactors the `common` module to use `compileOnly` for `metro-runtime`.