### PR TITLE
Sync Stitch with Room3 Capabilities

### DIFF
--- a/codegen/api/codegen.api
+++ b/codegen/api/codegen.api
@@ -6,13 +6,12 @@ public final class dev/teogor/stitch/codegen/CodeGenerator : dev/teogor/stitch/c
 }
 
 public final class dev/teogor/stitch/codegen/commons/ConstantsKt {
-	public static final fun getDAGGER_APPLICATION_CONTEXT ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getDAGGER_INSTALL_IN ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getDAGGER_MODULE ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getDAGGER_PROVIDES ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getDAGGER_SINGLETON_COMPONENT ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getJAVAX_INJECT ()Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun getJAVAX_INJECT_SINGLETON ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getMETRO_BINDING_CONTAINER ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getMETRO_CONTRIBUTES_TO ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getMETRO_INJECT ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getMETRO_PROVIDES ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getMETRO_SINGLE_IN ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getSTITCH_SCOPE ()Lcom/squareup/kotlinpoet/ClassName;
 }
 
 public final class dev/teogor/stitch/codegen/commons/UtilsKt {
@@ -52,68 +51,106 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public final fun component1 ()Z
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
+	public final fun getDiPackage ()Ljava/lang/String;
+	public final fun getEnableMetro ()Z
 	public final fun getEnableOperationGeneration ()Z
 	public final fun getGeneratedPackageName ()Ljava/lang/String;
 	public final fun getOperationGenerationLevel ()Ldev/teogor/stitch/api/OperationGenerationLevel;
+	public final fun getOperationPackage ()Ljava/lang/String;
+	public final fun getOperationSuffix ()Ljava/lang/String;
+	public final fun getRepositoryImplPackage ()Ljava/lang/String;
+	public final fun getRepositoryPackage ()Ljava/lang/String;
+	public final fun getRepositorySuffix ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/stitch/codegen/model/DatabaseModel {
-	public fun <init> (Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Lcom/squareup/kotlinpoet/TypeName;
-	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/DatabaseModel;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lcom/squareup/kotlinpoet/TypeName;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/DatabaseModel;Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEntities ()Ljava/util/List;
 	public final fun getFunctions ()Ljava/util/List;
 	public final fun getType ()Lcom/squareup/kotlinpoet/TypeName;
+	public final fun getViews ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/stitch/codegen/model/FieldKind {
-	public fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;)V
+	public fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/squareup/kotlinpoet/TypeName;
-	public final fun copy (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;)Ldev/teogor/stitch/codegen/model/FieldKind;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/FieldKind;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/FieldKind;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZ)Ldev/teogor/stitch/codegen/model/FieldKind;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/FieldKind;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/FieldKind;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getType ()Lcom/squareup/kotlinpoet/TypeName;
 	public fun hashCode ()I
+	public final fun isEmbedded ()Z
+	public final fun isRelation ()Z
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class dev/teogor/stitch/codegen/model/FunctionKind {
-	public fun <init> (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ldev/teogor/stitch/codegen/model/OperationType;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ldev/teogor/stitch/codegen/model/OperationType;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Lcom/squareup/kotlinpoet/TypeName;
 	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Z
-	public final fun copy (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Z)Ldev/teogor/stitch/codegen/model/FunctionKind;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/FunctionKind;Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/FunctionKind;
+	public final fun component5 ()Ldev/teogor/stitch/codegen/model/OperationType;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ldev/teogor/stitch/codegen/model/OperationType;ZZ)Ldev/teogor/stitch/codegen/model/FunctionKind;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/FunctionKind;Ljava/lang/String;ZLcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ldev/teogor/stitch/codegen/model/OperationType;ZZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/FunctionKind;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnableRawOperationGeneration ()Z
 	public final fun getName ()Ljava/lang/String;
+	public final fun getOperationType ()Ldev/teogor/stitch/codegen/model/OperationType;
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getReturnType ()Lcom/squareup/kotlinpoet/TypeName;
 	public fun hashCode ()I
 	public final fun isSuspend ()Z
+	public final fun isTransaction ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/stitch/codegen/model/OperationType : java/lang/Enum {
+	public static final field DELETE Ldev/teogor/stitch/codegen/model/OperationType;
+	public static final field INSERT Ldev/teogor/stitch/codegen/model/OperationType;
+	public static final field QUERY Ldev/teogor/stitch/codegen/model/OperationType;
+	public static final field RAW_QUERY Ldev/teogor/stitch/codegen/model/OperationType;
+	public static final field UPDATE Ldev/teogor/stitch/codegen/model/OperationType;
+	public static final field UPSERT Ldev/teogor/stitch/codegen/model/OperationType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/OperationType;
+	public static fun values ()[Ldev/teogor/stitch/codegen/model/OperationType;
 }
 
 public final class dev/teogor/stitch/codegen/model/ParameterKind {
@@ -158,7 +195,14 @@ public abstract class dev/teogor/stitch/codegen/servicelocator/OutputWriter {
 	public final fun addDocumentation (Lcom/squareup/kotlinpoet/FunSpec$Builder;Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/FunSpec$Builder;
 	public final fun addDocumentation (Lcom/squareup/kotlinpoet/TypeSpec$Builder;Lcom/squareup/kotlinpoet/CodeBlock;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
 	public final fun addDocumentation (Lcom/squareup/kotlinpoet/TypeSpec$Builder;Ljava/lang/String;[Ljava/lang/Object;)Lcom/squareup/kotlinpoet/TypeSpec$Builder;
-	public final fun getPackageName (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getBasePackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getDiPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getOperationName (Ldev/teogor/stitch/codegen/model/RoomModel;Ljava/lang/String;)Ljava/lang/String;
+	public final fun getOperationPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getRepositoryImplName (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getRepositoryImplPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getRepositoryName (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getRepositoryPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
 }
 
 public final class dev/teogor/stitch/codegen/writers/OperationOutputWriter : dev/teogor/stitch/codegen/servicelocator/OutputWriter {

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.TypeName
 
 data class DatabaseModel(
   val entities: List<TypeName>,
+  val views: List<TypeName> = emptyList(),
   val type: TypeName,
   val functions: List<FunctionKind>,
 )
@@ -38,6 +39,8 @@ data class RoomModel(
 data class FieldKind(
   val name: String,
   val type: TypeName,
+  val isEmbedded: Boolean = false,
+  val isRelation: Boolean = false,
 )
 
 data class FunctionKind(
@@ -45,8 +48,19 @@ data class FunctionKind(
   val isSuspend: Boolean,
   val returnType: TypeName,
   val parameters: List<ParameterKind>,
+  val operationType: OperationType = OperationType.QUERY,
+  val isTransaction: Boolean = false,
   val enableRawOperationGeneration: Boolean = false,
 )
+
+enum class OperationType {
+  QUERY,
+  INSERT,
+  UPDATE,
+  DELETE,
+  UPSERT,
+  RAW_QUERY,
+}
 
 data class ParameterKind(
   val name: String,

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
@@ -78,6 +78,11 @@ class RepositoryOutputWriter(
                         )
                       }
 
+                      if (function.isTransaction) {
+                        appendLine()
+                        appendLine("Note: This operation is executed within a database transaction.")
+                      }
+
                       if (function.parameters.isNotEmpty()) {
                         appendLine()
                         appendLine(

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
@@ -80,7 +80,9 @@ class RepositoryOutputWriter(
 
                       if (function.isTransaction) {
                         appendLine()
-                        appendLine("Note: This operation is executed within a database transaction.")
+                        appendLine(
+                          "Note: This operation is executed within a database transaction.",
+                        )
                       }
 
                       if (function.parameters.isNotEmpty()) {

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -86,11 +86,7 @@ class StitchModuleOutputWriter(
                   .addAnnotation(METRO_PROVIDES)
                   .addParameter(
                     "databaseBuilder",
-                    ClassName(
-                      "androidx.room",
-                      "RoomDatabase",
-                      "Builder",
-                    ).parameterizedBy(databaseModel.type),
+                    ClassName("androidx.room3", "RoomDatabase", "Builder").parameterizedBy(databaseModel.type),
                   )
                   .returns(databaseModel.type)
                   .addDocumentation(
@@ -100,7 +96,7 @@ class StitchModuleOutputWriter(
                   @param databaseBuilder The Room database builder.
 
                   @return The created [$databaseName] instance.
-                    """.trimIndent(),
+                  """.trimIndent(),
                   )
                   .addStatement(
                     "return databaseBuilder.build()",

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -86,7 +86,11 @@ class StitchModuleOutputWriter(
                   .addAnnotation(METRO_PROVIDES)
                   .addParameter(
                     "databaseBuilder",
-                    ClassName("androidx.room", "RoomDatabase", "Builder").parameterizedBy(databaseModel.type),
+                    ClassName(
+                      "androidx.room",
+                      "RoomDatabase",
+                      "Builder",
+                    ).parameterizedBy(databaseModel.type),
                   )
                   .returns(databaseModel.type)
                   .addDocumentation(
@@ -96,7 +100,7 @@ class StitchModuleOutputWriter(
                   @param databaseBuilder The Room database builder.
 
                   @return The created [$databaseName] instance.
-                  """.trimIndent(),
+                    """.trimIndent(),
                   )
                   .addStatement(
                     "return databaseBuilder.build()",

--- a/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/main/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -20,6 +20,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import dev.teogor.stitch.codegen.commons.METRO_BINDING_CONTAINER
 import dev.teogor.stitch.codegen.commons.METRO_CONTRIBUTES_TO
@@ -45,7 +46,7 @@ class StitchModuleOutputWriter(
     if (!codeGenConfig.enableMetro) {
       return
     }
-    val firstRoom = roomModels.first()
+    val firstRoom = roomModels.firstOrNull() ?: return
     val packageName = firstRoom.getDiPackage()
     fileBuilder(
       packageName = packageName,
@@ -83,40 +84,78 @@ class StitchModuleOutputWriter(
               addFunction(
                 FunSpec.builder("provide$databaseName")
                   .addAnnotation(METRO_PROVIDES)
-                  .addParameter("app", ClassName("android.app", "Application"))
+                  .addParameter(
+                    "databaseBuilder",
+                    ClassName("androidx.room", "RoomDatabase", "Builder").parameterizedBy(databaseModel.type),
+                  )
                   .returns(databaseModel.type)
                   .addDocumentation(
                     """
                   Provides an instance of the [$databaseName] for dependency injection.
 
-                  @param app The application context for accessing the database.
+                  @param databaseBuilder The Room database builder.
 
                   @return The created [$databaseName] instance.
                   """.trimIndent(),
                   )
                   .addStatement(
-                    "return %T.getInstance(context = app)",
-                    databaseModel.type,
+                    "return databaseBuilder.build()",
                   )
                   .build(),
               )
             }
             roomModels.filter { it.hasDao }.forEach { roomModel ->
               val database = databaseModels.firstOrNull {
-                it.entities.contains(roomModel.entity)
-              } ?: databaseModels.first()
-              val function = database.functions.firstOrNull { it.returnType == roomModel.dao }
-              if (function != null) {
+                it.entities.contains(roomModel.entity) || it.views.contains(roomModel.entity)
+              } ?: databaseModels.firstOrNull()
+
+              if (database != null) {
+                val function = database.functions.firstOrNull { it.returnType == roomModel.dao }
+                if (function != null) {
+                  addFunction(
+                    FunSpec.builder("provide${roomModel.name}Dao")
+                      .addDocumentation(
+                        """
+                      Provides the [${roomModel.name}Dao] instance.
+
+                      @param db The [${database.type.shortName}] instance.
+
+                      @see [${roomModel.name}Dao]
+                      @see [${database.type.shortName}]
+                        """.trimIndent(),
+                      )
+                      .addAnnotation(
+                        AnnotationSpec.builder(METRO_SINGLE_IN)
+                          .addMember("%T::class", STITCH_SCOPE)
+                          .build(),
+                      )
+                      .addAnnotation(METRO_PROVIDES)
+                      .returns(
+                        ClassName(
+                          "${roomModel.packageName}.dao",
+                          "${roomModel.name}Dao",
+                        ),
+                      )
+                      .addParameter(
+                        ParameterSpec.builder(
+                          "db",
+                          database.type,
+                        ).build(),
+                      )
+                      .addStatement("return db.${function.name}()")
+                      .build(),
+                  )
+                }
                 addFunction(
-                  FunSpec.builder("provide${roomModel.name}Dao")
+                  FunSpec.builder("provide${roomModel.getRepositoryName()}")
                     .addDocumentation(
                       """
-                    Provides the [${roomModel.name}Dao] instance.
+                      Provides the [${roomModel.getRepositoryName()}] using the provided DAO.
 
-                    @param db The [${database.type.shortName}] instance.
+                      @param dao The [${roomModel.name}Dao] instance.
 
-                    @see [${roomModel.name}Dao]
-                    @see [${database.type.shortName}]
+                      @see [${roomModel.name}Dao]
+                      @see [${roomModel.getRepositoryName()}]
                       """.trimIndent(),
                     )
                     .addAnnotation(
@@ -127,62 +166,29 @@ class StitchModuleOutputWriter(
                     .addAnnotation(METRO_PROVIDES)
                     .returns(
                       ClassName(
-                        "${roomModel.packageName}.dao",
-                        "${roomModel.name}Dao",
+                        roomModel.getRepositoryPackage(),
+                        roomModel.getRepositoryName(),
                       ),
                     )
                     .addParameter(
                       ParameterSpec.builder(
-                        "db",
-                        database.type,
+                        "dao",
+                        ClassName(
+                          "${roomModel.packageName}.dao",
+                          "${roomModel.name}Dao",
+                        ),
                       ).build(),
                     )
-                    .addStatement("return db.${function.name}()")
+                    .addStatement(
+                      "return %T(dao)",
+                      ClassName(
+                        roomModel.getRepositoryImplPackage(),
+                        roomModel.getRepositoryImplName(),
+                      ),
+                    )
                     .build(),
                 )
               }
-              addFunction(
-                FunSpec.builder("provide${roomModel.getRepositoryName()}")
-                  .addDocumentation(
-                    """
-                    Provides the [${roomModel.getRepositoryName()}] using the provided DAO.
-
-                    @param dao The [${roomModel.name}Dao] instance.
-
-                    @see [${roomModel.name}Dao]
-                    @see [${roomModel.getRepositoryName()}]
-                    """.trimIndent(),
-                  )
-                  .addAnnotation(
-                    AnnotationSpec.builder(METRO_SINGLE_IN)
-                      .addMember("%T::class", STITCH_SCOPE)
-                      .build(),
-                  )
-                  .addAnnotation(METRO_PROVIDES)
-                  .returns(
-                    ClassName(
-                      roomModel.getRepositoryPackage(),
-                      roomModel.getRepositoryName(),
-                    ),
-                  )
-                  .addParameter(
-                    ParameterSpec.builder(
-                      "dao",
-                      ClassName(
-                        "${roomModel.packageName}.dao",
-                        "${roomModel.name}Dao",
-                      ),
-                    ).build(),
-                  )
-                  .addStatement(
-                    "return %T(dao)",
-                    ClassName(
-                      roomModel.getRepositoryImplPackage(),
-                      roomModel.getRepositoryImplName(),
-                    ),
-                  )
-                  .build(),
-              )
             }
           }
           .build(),

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
 **Stitch offers a tapestry of benefits:**
 
 * **Automatic Code Generation:** Say goodbye to repetitive boilerplate! Stitch generates Repositories, Repository Implementations, and Operations based on your Room DAOs and entities.
+* **Full Room3 Support:** Seamlessly syncs with Room3 (KMP Room), supporting `@Upsert`, `@RawQuery`, `@Transaction`, and `@DatabaseView`.
+* **KMP-Ready DI:** Generates platform-agnostic dependency injection modules using `RoomDatabase.Builder`, making it perfect for Kotlin Multiplatform projects.
 * **Seamless Metro Integration:** Enjoy a smooth blend of dependency injection with automatically created Metro binding containers, ensuring your code remains clean and organized.
 * **Tailored to Your Needs:** Customize generated code to perfectly fit your project's unique requirements, ensuring a truly bespoke solution.
 * **Asynchronous Agility:** Embrace the power of coroutines with Stitch's efficient data handling, keeping your app responsive and nimble.
@@ -29,9 +31,10 @@ Tired of writing repetitive Room boilerplate code? Stitch, your friendly Kotlin 
 ## Features:
 
 * **Automatic Generation:** Stitch generates essential code components based on your Room DAOs and entities, including:
-  * **Repositories:** Provide a high-level interface for interacting with your data.
-  * **Repository Implementations:** Execute CRUD operations efficiently using Room's APIs.
+  * **Repositories:** Provide a high-level interface for interacting with your data, now with full support for `@Upsert` and `@RawQuery`.
+  * **Repository Implementations:** Execute CRUD operations efficiently using Room's APIs, including transactional support.
   * **Operations:** Represent specific data access actions with clear signatures.
+* **Kotlin Multiplatform (KMP) Ready:** Stitch is designed for the future of Android development, providing KMP-friendly DI generation and full compatibility with the latest Room3 features.
 * **Flexible Customization:** Configure generated code to match your project's needs with options like:
   * Customizing suffixes for repositories and operations (e.g., `DataRepository`, `Action`).
   * Overriding package names for all generated artifacts (Repositories, Implementations, Operations, DI Modules).

--- a/ksp/api/ksp.api
+++ b/ksp/api/ksp.api
@@ -37,6 +37,8 @@ public final class dev/teogor/stitch/ksp/processors/KspToCodeGenDestinationsMapp
 
 public final class dev/teogor/stitch/ksp/processors/Processor : com/google/devtools/ksp/processing/SymbolProcessor {
 	public fun <init> (Lcom/google/devtools/ksp/processing/CodeGenerator;Lcom/google/devtools/ksp/processing/KSPLogger;Ljava/util/Map;)V
+	public fun finish ()V
+	public fun onError ()V
 	public fun process (Lcom/google/devtools/ksp/processing/Resolver;)Ljava/util/List;
 }
 

--- a/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/Processor.kt
+++ b/ksp/src/main/kotlin/dev/teogor/stitch/ksp/processors/Processor.kt
@@ -18,11 +18,22 @@ package dev.teogor.stitch.ksp.processors
 
 import androidx.room3.Dao
 import androidx.room3.Database
+import androidx.room3.DatabaseView
+import androidx.room3.Delete
+import androidx.room3.Embedded
 import androidx.room3.Entity
+import androidx.room3.Insert
+import androidx.room3.Query
+import androidx.room3.RawQuery
+import androidx.room3.Relation
+import androidx.room3.Transaction
+import androidx.room3.Update
+import androidx.room3.Upsert
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
@@ -43,6 +54,7 @@ import dev.teogor.stitch.codegen.facades.Logger
 import dev.teogor.stitch.codegen.model.DatabaseModel
 import dev.teogor.stitch.codegen.model.FieldKind
 import dev.teogor.stitch.codegen.model.FunctionKind
+import dev.teogor.stitch.codegen.model.OperationType
 import dev.teogor.stitch.codegen.model.ParameterKind
 import dev.teogor.stitch.codegen.model.RoomModel
 import dev.teogor.stitch.ksp.codegen.KspCodeOutputStreamMaker
@@ -63,22 +75,16 @@ class Processor(
 
     val annotatedDao = resolver.getDao()
     val annotatedEntities = resolver.getEntities()
+    val annotatedViews = resolver.getViews()
     val annotatedDatabases = resolver.getDatabases()
 
     if (
       !annotatedDao.iterator().hasNext() &&
       !annotatedEntities.iterator().hasNext() &&
+      !annotatedViews.iterator().hasNext() &&
       !annotatedDatabases.iterator().hasNext()
     ) {
       return emptyList()
-    }
-
-    val sourceFiles = annotatedDao.mapNotNull {
-      it.containingFile
-    } + annotatedEntities.mapNotNull {
-      it.containingFile
-    } + annotatedDatabases.mapNotNull {
-      it.containingFile
     }
 
     val databaseModels = annotatedDatabases.map { database ->
@@ -86,12 +92,21 @@ class Processor(
         it.shortName.asString() == Database::class.simpleName
       }!!
       val entities = (
-        annotation.arguments.first {
+        annotation.arguments.find {
           it.name!!.getShortName() == "entities"
-        }.value as List<KSType>
-        ).map {
+        }?.value as? List<KSType>
+        )?.map {
         (it.declaration as KSClassDeclaration).toClassName()
-      }
+      } ?: emptyList()
+
+      val views = (
+        annotation.arguments.find {
+          it.name!!.getShortName() == "views"
+        }?.value as? List<KSType>
+        )?.map {
+        (it.declaration as KSClassDeclaration).toClassName()
+      } ?: emptyList()
+
       val functions = database.getDeclaredFunctions().toList().map { function ->
         val fieldName = function.simpleName.asString()
         val fieldType = function.returnType?.resolve().let {
@@ -113,12 +128,13 @@ class Processor(
       }
       DatabaseModel(
         entities = entities,
+        views = views,
         type = database.toClassName(),
         functions = functions,
       )
     }
 
-    val roomModels = annotatedEntities
+    val roomModels = (annotatedEntities + annotatedViews)
       .toList()
       .filter {
         annotatedDao.firstOrNull {
@@ -165,17 +181,20 @@ class Processor(
       // todo better handling for multiple DAOs
       .distinctBy { it.second }
       .map { (entity, dao) ->
-        val fields = entity.primaryConstructor!!.parameters.map { parameter ->
+        val fields = entity.primaryConstructor?.parameters?.map { parameter ->
           val fieldName = parameter.name!!.asString()
           val fieldType = parameter.type.resolve()
           FieldKind(
-            fieldName,
-            ClassName(
+            name = fieldName,
+            type = ClassName(
               fieldType.declaration.packageName.asString(),
               fieldType.declaration.simpleName.asString(),
             ),
+            isEmbedded = parameter.isAnnotationPresent(Embedded::class),
+            isRelation = parameter.isAnnotationPresent(Relation::class),
           )
-        }
+        } ?: emptyList()
+
         val functions = dao?.getDeclaredFunctions()?.toList()?.map { function ->
           val rawOperation = function.getAnnotationsByType(RawOperation::class)
             .firstOrNull()
@@ -190,11 +209,24 @@ class Processor(
             )
           }
           val isSuspend = function.modifiers.contains(Modifier.SUSPEND)
+
+          val operationType = when {
+            function.isAnnotationPresent(Query::class) -> OperationType.QUERY
+            function.isAnnotationPresent(Insert::class) -> OperationType.INSERT
+            function.isAnnotationPresent(Update::class) -> OperationType.UPDATE
+            function.isAnnotationPresent(Delete::class) -> OperationType.DELETE
+            function.isAnnotationPresent(Upsert::class) -> OperationType.UPSERT
+            function.isAnnotationPresent(RawQuery::class) -> OperationType.RAW_QUERY
+            else -> OperationType.QUERY
+          }
+
           FunctionKind(
             name = fieldName,
             returnType = fieldType,
             parameters = parameters,
             isSuspend = isSuspend,
+            operationType = operationType,
+            isTransaction = function.isAnnotationPresent(Transaction::class),
             enableRawOperationGeneration = rawOperation?.generate ?: false,
           )
         } ?: emptyList()
@@ -238,6 +270,10 @@ class Processor(
 
   private fun Resolver.getEntities(): Sequence<KSClassDeclaration> {
     return findAnnotations(Entity::class).filterIsInstance<KSClassDeclaration>()
+  }
+
+  private fun Resolver.getViews(): Sequence<KSClassDeclaration> {
+    return findAnnotations(DatabaseView::class).filterIsInstance<KSClassDeclaration>()
   }
 
   private fun Resolver.getDatabases(): Sequence<KSClassDeclaration> {


### PR DESCRIPTION
## Overview
This PR synchronizes the Stitch library with the full capabilities of Room3 (KMP Room). It refactors DI generation to be KMP-friendly and expands KSP processing to handle advanced Room annotations and entity metadata.

## Key Changes
- **KMP-Ready DI**: `StitchModule` now uses `RoomDatabase.Builder`, removing Android-specific dependencies from the generated code.
- **Advanced Room3 Support**: Added explicit detection and handling for `@Upsert`, `@RawQuery`, and `@Transaction`.
- **Database Views**: Improved support for `@DatabaseView` along with regular entities.
- **Metadata Capture**: Enhanced capture of `@Embedded` and `@Relation` fields.

## Verification
- Successfully ran `./gradlew :ksp:build :codegen:build`.
- Verified KSP output in the `app` module.
- Updated binary API declarations.