### PR TITLE
fix(inventory): ensure default category exists to avoid foreign key crash

### DIFF
--- a/app/src/main/kotlin/dev/teogor/stitch/core/ui/InventoryScreen.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/ui/InventoryScreen.kt
@@ -43,12 +43,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.teogor.stitch.core.database.model.InventoryCategory
 import dev.teogor.stitch.core.database.model.InventoryProduct
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun inventoryScreen(viewModel: InventoryViewModel) {
   val products by viewModel.products.collectAsState()
+  val categories by viewModel.categories.collectAsState()
   val searchQuery by viewModel.searchQuery.collectAsState()
 
   Scaffold(
@@ -73,9 +75,12 @@ fun inventoryScreen(viewModel: InventoryViewModel) {
 
       Spacer(modifier = Modifier.padding(8.dp))
 
-      addProductSection(onAddProduct = { name, price ->
-        viewModel.addProduct(name, 1L, price, 10) // Simplified for demo
-      })
+      addProductSection(
+        categories = categories,
+        onAddProduct = { name, categoryId, price ->
+          viewModel.addProduct(name, categoryId, price, 10)
+        },
+      )
 
       Spacer(modifier = Modifier.padding(8.dp))
 
@@ -95,7 +100,10 @@ fun inventoryScreen(viewModel: InventoryViewModel) {
 }
 
 @Composable
-fun addProductSection(onAddProduct: (String, Double) -> Unit) {
+fun addProductSection(
+  categories: List<InventoryCategory>,
+  onAddProduct: (String, Long, Double) -> Unit,
+) {
   var name by remember { mutableStateOf("") }
   var price by remember { mutableStateOf("") }
 
@@ -118,8 +126,9 @@ fun addProductSection(onAddProduct: (String, Double) -> Unit) {
       )
       Button(
         onClick = {
+          val categoryId = categories.firstOrNull()?.id ?: 1L
           if (name.isNotBlank() && price.toDoubleOrNull() != null) {
-            onAddProduct(name, price.toDouble())
+            onAddProduct(name, categoryId, price.toDouble())
             name = ""
             price = ""
           }

--- a/app/src/main/kotlin/dev/teogor/stitch/core/ui/InventoryViewModel.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/core/ui/InventoryViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -50,6 +51,16 @@ class InventoryViewModel(
 
   val categories: StateFlow<List<InventoryCategory>> = categoryRepository.getAll()
     .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+  init {
+    viewModelScope.launch {
+      categoryRepository.getAll().first().let { categories ->
+        if (categories.isEmpty()) {
+          categoryRepository.insert(InventoryCategory(name = "General"))
+        }
+      }
+    }
+  }
 
   fun updateSearchQuery(query: String) {
     _searchQuery.value = query


### PR DESCRIPTION
This PR fixes a crash that occurred when attempting to add a new item to the inventory. The crash was due to an `android.database.SQLException: Error code: 787, message: FOREIGN KEY constraint failed` because a hardcoded category ID was used that didn't exist in the database.\n\nChanges:\n- Added an `init` block in `InventoryViewModel` to ensure a "General" category exists.\n- Updated `InventoryScreen` to use categories from the database.