### PR TITLE
feat(codegen): implement visibility control for generated code

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -51,20 +51,14 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-	public final fun component1 ()Z
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Z
-	public final fun component12 ()Ljava/lang/String;
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
 	public final fun component12 ()Ldev/teogor/stitch/api/DiFramework;
 	public final fun component13 ()Ljava/lang/String;
->>>>>>> feature/domain-mapping
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ldev/teogor/stitch/api/Visibility;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -73,13 +67,8 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-<<<<<<< HEAD
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-=======
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
->>>>>>> feature/domain-mapping
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
@@ -95,6 +84,7 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun getRepositoryImplPackage ()Ljava/lang/String;
 	public final fun getRepositoryPackage ()Ljava/lang/String;
 	public final fun getRepositorySuffix ()Ljava/lang/String;
+	public final fun getVisibility ()Ldev/teogor/stitch/api/Visibility;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -228,6 +218,7 @@ public abstract class dev/teogor/stitch/codegen/writers/OutputWriter {
 	public final fun getRepositoryImplPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
 	public final fun getRepositoryName (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
 	public final fun getRepositoryPackage (Ldev/teogor/stitch/codegen/model/RoomModel;)Ljava/lang/String;
+	public final fun getVisibility ()Lcom/squareup/kotlinpoet/KModifier;
 }
 
 public final class dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter : dev/teogor/stitch/codegen/writers/OutputWriter {

--- a/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -18,6 +18,7 @@ package dev.teogor.stitch.codegen.model
 
 import dev.teogor.stitch.api.DiFramework
 import dev.teogor.stitch.api.OperationGenerationLevel
+import dev.teogor.stitch.api.Visibility
 
 data class CodeGenConfig(
   val addDocumentation: Boolean,
@@ -35,4 +36,5 @@ data class CodeGenConfig(
   val diFramework: DiFramework,
   val injectAnnotation: String?,
   val repositoryBaseClass: String?,
+  val visibility: Visibility,
 )

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OperationOutputWriter.kt
@@ -99,6 +99,7 @@ class OperationOutputWriter(
         ) {
           addType(
             TypeSpec.classBuilder(className)
+              .addModifiers(getVisibility())
               .apply {
                 addAnnotation(Operation::class)
                 addProperty(

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OutputWriter.kt
@@ -18,7 +18,9 @@ package dev.teogor.stitch.codegen.writers
 
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
+import dev.teogor.stitch.api.Visibility
 import dev.teogor.stitch.codegen.commons.titleCase
 import dev.teogor.stitch.codegen.model.CodeGenConfig
 import dev.teogor.stitch.codegen.model.RoomModel
@@ -26,6 +28,11 @@ import dev.teogor.stitch.codegen.model.RoomModel
 abstract class OutputWriter(
   internal val codeGenConfig: CodeGenConfig,
 ) {
+
+  fun getVisibility(): KModifier = when (codeGenConfig.visibility) {
+    Visibility.PUBLIC -> KModifier.PUBLIC
+    Visibility.INTERNAL -> KModifier.INTERNAL
+  }
 
   fun RoomModel.getBasePackage() = codeGenConfig.generatedPackageName ?: packageName
 

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
@@ -44,6 +44,7 @@ class RepositoryImplOutputWriter(
     ) {
       addType(
         TypeSpec.classBuilder(repositoryImplName)
+          .addModifiers(getVisibility())
           .addSuperinterface(repositoryType)
           .addDocumentation(
             """

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
@@ -44,6 +44,7 @@ class RepositoryOutputWriter(
     ) {
       addType(
         TypeSpec.interfaceBuilder(repositoryName)
+          .addModifiers(getVisibility())
           .apply {
             codeGenConfig.repositoryBaseClass?.let { baseClass ->
               addSuperinterface(ClassName.bestGuess(baseClass))

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -54,6 +54,7 @@ class StitchModuleOutputWriter(
     ) {
       addType(
         TypeSpec.objectBuilder("StitchModule")
+          .addModifiers(getVisibility())
           .addAnnotation(METRO_BINDING_CONTAINER)
           .addAnnotation(
             AnnotationSpec.builder(METRO_CONTRIBUTES_TO)

--- a/common/api/jvm/common.api
+++ b/common/api/jvm/common.api
@@ -67,6 +67,7 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun getRepositoryImplPackage ()Ljava/lang/String;
 	public abstract fun getRepositoryPackage ()Ljava/lang/String;
 	public abstract fun getRepositorySuffix ()Ljava/lang/String;
+	public abstract fun getVisibility ()Ldev/teogor/stitch/api/Visibility;
 	public abstract fun setAddDocumentation (Z)V
 	public abstract fun setDiFramework (Ldev/teogor/stitch/api/DiFramework;)V
 	public abstract fun setDiPackage (Ljava/lang/String;)V
@@ -81,6 +82,20 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun setRepositoryImplPackage (Ljava/lang/String;)V
 	public abstract fun setRepositoryPackage (Ljava/lang/String;)V
 	public abstract fun setRepositorySuffix (Ljava/lang/String;)V
+	public abstract fun setVisibility (Ldev/teogor/stitch/api/Visibility;)V
+}
+
+public final class dev/teogor/stitch/api/Visibility : java/lang/Enum {
+	public static final field Companion Ldev/teogor/stitch/api/Visibility$Companion;
+	public static final field INTERNAL Ldev/teogor/stitch/api/Visibility;
+	public static final field PUBLIC Ldev/teogor/stitch/api/Visibility;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/stitch/api/Visibility;
+	public static fun values ()[Ldev/teogor/stitch/api/Visibility;
+}
+
+public final class dev/teogor/stitch/api/Visibility$Companion {
+	public final fun from (Ljava/lang/String;)Ldev/teogor/stitch/api/Visibility;
 }
 
 public abstract class dev/teogor/stitch/di/StitchScope {

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -159,4 +159,11 @@ interface StitchExtension {
    * Provide the fully qualified name.
    */
   var repositoryBaseClass: String?
+
+  /**
+   * Defines the visibility for generated classes and interfaces.
+   *
+   * By default, this is set to [Visibility.PUBLIC].
+   */
+  var visibility: Visibility
 }

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
@@ -28,7 +28,9 @@ enum class Visibility {
   /**
    * Generated code will be internal to the module.
    */
-  INTERNAL;
+  INTERNAL,
+
+  ;
 
   companion object {
     /**

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
@@ -28,5 +28,20 @@ enum class Visibility {
   /**
    * Generated code will be internal to the module.
    */
-  INTERNAL,
+  INTERNAL;
+
+  companion object {
+    /**
+     * Converts a string representation to the corresponding [Visibility].
+     *
+     * This function supports case-insensitive matching and returns [PUBLIC] for invalid input.
+     *
+     * @param string The string to convert.
+     * @return The corresponding [Visibility] or [PUBLIC] if not found.
+     */
+    fun from(string: String): Visibility {
+      return entries.firstOrNull { it.name.lowercase() == string.lowercase() }
+        ?: PUBLIC
+    }
+  }
 }

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/Visibility.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.api
+
+/**
+ * Defines the visibility levels for generated Stitch code.
+ */
+enum class Visibility {
+  /**
+   * Generated code will be public.
+   */
+  PUBLIC,
+
+  /**
+   * Generated code will be internal to the module.
+   */
+  INTERNAL,
+}

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -20,6 +20,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun getRepositoryImplPackage ()Ljava/lang/String;
 	public fun getRepositoryPackage ()Ljava/lang/String;
 	public fun getRepositorySuffix ()Ljava/lang/String;
+	public fun getVisibility ()Ldev/teogor/stitch/api/Visibility;
 	public fun setAddDocumentation (Z)V
 	public fun setDiFramework (Ldev/teogor/stitch/api/DiFramework;)V
 	public fun setDiPackage (Ljava/lang/String;)V
@@ -34,15 +35,12 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun setRepositoryImplPackage (Ljava/lang/String;)V
 	public fun setRepositoryPackage (Ljava/lang/String;)V
 	public fun setRepositorySuffix (Ljava/lang/String;)V
+	public fun setVisibility (Ldev/teogor/stitch/api/Visibility;)V
 }
 
 public final class dev/teogor/stitch/StitchSchemaArgProvider : org/gradle/process/CommandLineArgumentProvider {
 	public static final field Companion Ldev/teogor/stitch/StitchSchemaArgProvider$Companion;
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
->>>>>>> feature/domain-mapping
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;)V
 	public synthetic fun asArguments ()Ljava/lang/Iterable;
 	public fun asArguments ()Ljava/util/List;
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -19,6 +19,7 @@ package dev.teogor.stitch
 import dev.teogor.stitch.api.DiFramework
 import dev.teogor.stitch.api.OperationGenerationLevel
 import dev.teogor.stitch.api.StitchExtension
+import dev.teogor.stitch.api.Visibility
 
 /**
  * Base implementation for the [StitchExtension] interface.
@@ -133,4 +134,11 @@ abstract class StitchExtensionImpl : StitchExtension {
    * Optional base class or interface for generated repository interfaces.
    */
   override var repositoryBaseClass: String? = null
+
+  /**
+   * Defines the visibility for generated classes and interfaces.
+   *
+   * By default, this is set to [Visibility.PUBLIC].
+   */
+  override var visibility: Visibility = Visibility.PUBLIC
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -19,6 +19,7 @@ package dev.teogor.stitch
 import dev.teogor.stitch.api.DiFramework
 import dev.teogor.stitch.api.OperationGenerationLevel
 import dev.teogor.stitch.api.StitchExtension
+import dev.teogor.stitch.api.Visibility
 import org.gradle.process.CommandLineArgumentProvider
 
 class StitchSchemaArgProvider(
@@ -33,12 +34,10 @@ class StitchSchemaArgProvider(
   private val operationPackage: String?,
   private val diPackage: String?,
   private val enableMetro: Boolean,
-<<<<<<< HEAD
-  private val repositoryBaseClass: String?,
-=======
   private val diFramework: DiFramework,
   private val injectAnnotation: String?,
->>>>>>> feature/domain-mapping
+  private val repositoryBaseClass: String?,
+  private val visibility: Visibility,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -50,16 +49,14 @@ class StitchSchemaArgProvider(
     "stitch.operationSuffix=$operationSuffix",
     "stitch.enableMetro=$enableMetro",
     "stitch.diFramework=$diFramework",
+    "stitch.visibility=$visibility",
   ) + listOfNotNull(
     repositoryPackage?.let { "stitch.repositoryPackage=$it" },
     repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
     operationPackage?.let { "stitch.operationPackage=$it" },
     diPackage?.let { "stitch.diPackage=$it" },
-<<<<<<< HEAD
-    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
-=======
     injectAnnotation?.let { "stitch.injectAnnotation=$it" },
->>>>>>> feature/domain-mapping
+    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
   )
 
   companion object {
@@ -76,12 +73,10 @@ class StitchSchemaArgProvider(
       operationPackage = stitchExtension.operationPackage,
       diPackage = stitchExtension.diPackage,
       enableMetro = stitchExtension.enableMetro,
-<<<<<<< HEAD
-      repositoryBaseClass = stitchExtension.repositoryBaseClass,
-=======
       diFramework = stitchExtension.diFramework,
       injectAnnotation = stitchExtension.injectAnnotation,
->>>>>>> feature/domain-mapping
+      repositoryBaseClass = stitchExtension.repositoryBaseClass,
+      visibility = stitchExtension.visibility,
     )
   }
 }

--- a/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
+++ b/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
@@ -20,6 +20,7 @@ package dev.teogor.stitch.ksp.processors
 
 import dev.teogor.stitch.api.DiFramework
 import dev.teogor.stitch.api.OperationGenerationLevel
+import dev.teogor.stitch.api.Visibility
 import dev.teogor.stitch.codegen.model.CodeGenConfig
 
 class ConfigParser(
@@ -44,6 +45,7 @@ class ConfigParser(
     private const val DI_FRAMEWORK = "$PREFIX.diFramework"
     private const val INJECT_ANNOTATION = "$PREFIX.injectAnnotation"
     private const val REPOSITORY_BASE_CLASS = "$PREFIX.repositoryBaseClass"
+    private const val VISIBILITY = "$PREFIX.visibility"
   }
 
   fun parse(): CodeGenConfig {
@@ -61,6 +63,7 @@ class ConfigParser(
     val diFramework = getDiFramework(enableMetro)
     val injectAnnotation = options[INJECT_ANNOTATION]?.trim()
     val repositoryBaseClass = options[REPOSITORY_BASE_CLASS]?.trim()
+    val visibility = getVisibility()
 
     return CodeGenConfig(
       addDocumentation = addDocumentation,
@@ -77,7 +80,15 @@ class ConfigParser(
       diFramework = diFramework,
       injectAnnotation = injectAnnotation,
       repositoryBaseClass = repositoryBaseClass,
+      visibility = visibility,
     )
+  }
+
+  private fun getVisibility(): Visibility {
+    val stringValue = options[VISIBILITY]?.trim()
+    stringValue ?: return Visibility.PUBLIC
+
+    return Visibility.from(stringValue)
   }
 
   private fun getDiFramework(enableMetro: Boolean): DiFramework {


### PR DESCRIPTION
This PR introduces the ability to control the visibility (public/internal) of the generated Stitch code.

### Changes:
- Added  enum to the common module.
- Updated  and  to include a  property.
- Modified  and  to pass the visibility setting to the code generation phase.
- Updated  and its subclasses (, , , ) to apply the correct visibility modifier to the generated types.

By default, the visibility remains  to maintain backward compatibility. Setting  in the Gradle configuration will now result in  generated classes and interfaces.