### PR TITLE
feat(codegen): implement Hilt and Dagger module generation

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -4,7 +4,12 @@ public final class dev/teogor/stitch/codegen/CodeGenerator {
 }
 
 public final class dev/teogor/stitch/codegen/commons/ConstantsKt {
+	public static final fun getDAGGER_MODULE ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getDAGGER_PROVIDES ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getHILT_INSTALL_IN ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getHILT_SINGLETON_COMPONENT ()Lcom/squareup/kotlinpoet/ClassName;
 	public static final fun getJAVAX_INJECT ()Lcom/squareup/kotlinpoet/ClassName;
+	public static final fun getJAVAX_SINGLETON ()Lcom/squareup/kotlinpoet/ClassName;
 	public static final fun getMETRO_BINDING_CONTAINER ()Lcom/squareup/kotlinpoet/ClassName;
 	public static final fun getMETRO_CONTRIBUTES_TO ()Lcom/squareup/kotlinpoet/ClassName;
 	public static final fun getMETRO_INJECT ()Lcom/squareup/kotlinpoet/ClassName;
@@ -51,20 +56,13 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-	public final fun component1 ()Z
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Z
-	public final fun component12 ()Ljava/lang/String;
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
 	public final fun component12 ()Ldev/teogor/stitch/api/DiFramework;
 	public final fun component13 ()Ljava/lang/String;
->>>>>>> feature/domain-mapping
+	public final fun component14 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -73,13 +71,8 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-<<<<<<< HEAD
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-=======
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
->>>>>>> feature/domain-mapping
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/commons/Constants.kt
@@ -46,3 +46,12 @@ val JAVAX_INJECT = ClassName(
   packageName = "javax.inject",
   "Inject",
 )
+val JAVAX_SINGLETON = ClassName(
+  packageName = "javax.inject",
+  "Singleton",
+)
+
+val DAGGER_MODULE = ClassName("dagger", "Module")
+val DAGGER_PROVIDES = ClassName("dagger", "Provides")
+val HILT_INSTALL_IN = ClassName("dagger.hilt", "InstallIn")
+val HILT_SINGLETON_COMPONENT = ClassName("dagger.hilt.components", "SingletonComponent")

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -23,6 +23,11 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import dev.teogor.stitch.api.DiFramework
+import dev.teogor.stitch.codegen.commons.DAGGER_MODULE
+import dev.teogor.stitch.codegen.commons.DAGGER_PROVIDES
+import dev.teogor.stitch.codegen.commons.HILT_INSTALL_IN
+import dev.teogor.stitch.codegen.commons.HILT_SINGLETON_COMPONENT
+import dev.teogor.stitch.codegen.commons.JAVAX_SINGLETON
 import dev.teogor.stitch.codegen.commons.METRO_BINDING_CONTAINER
 import dev.teogor.stitch.codegen.commons.METRO_CONTRIBUTES_TO
 import dev.teogor.stitch.codegen.commons.METRO_PROVIDES
@@ -43,9 +48,11 @@ class StitchModuleOutputWriter(
 ) : OutputWriter(codeGenConfig) {
 
   fun write(databaseModels: Sequence<DatabaseModel>, roomModels: List<RoomModel>) {
-    if (codeGenConfig.diFramework != DiFramework.METRO) {
+    val diFramework = codeGenConfig.diFramework
+    if (diFramework == DiFramework.NONE) {
       return
     }
+
     val firstRoom = roomModels.firstOrNull() ?: return
     val packageName = firstRoom.getDiPackage()
     fileBuilder(
@@ -54,12 +61,33 @@ class StitchModuleOutputWriter(
     ) {
       addType(
         TypeSpec.objectBuilder("StitchModule")
-          .addAnnotation(METRO_BINDING_CONTAINER)
-          .addAnnotation(
-            AnnotationSpec.builder(METRO_CONTRIBUTES_TO)
-              .addMember("%T::class", STITCH_SCOPE)
-              .build(),
-          )
+          .apply {
+            when (diFramework) {
+              DiFramework.METRO -> {
+                addAnnotation(METRO_BINDING_CONTAINER)
+                addAnnotation(
+                  AnnotationSpec.builder(METRO_CONTRIBUTES_TO)
+                    .addMember("%T::class", STITCH_SCOPE)
+                    .build(),
+                )
+              }
+
+              DiFramework.HILT -> {
+                addAnnotation(DAGGER_MODULE)
+                addAnnotation(
+                  AnnotationSpec.builder(HILT_INSTALL_IN)
+                    .addMember("%T::class", HILT_SINGLETON_COMPONENT)
+                    .build(),
+                )
+              }
+
+              DiFramework.DAGGER -> {
+                addAnnotation(DAGGER_MODULE)
+              }
+
+              else -> {}
+            }
+          }
           .addDocumentation(
             """
             This object provides the Stitch module for dependency injection.
@@ -83,7 +111,13 @@ class StitchModuleOutputWriter(
               }
               addFunction(
                 FunSpec.builder("provide$databaseName")
-                  .addAnnotation(METRO_PROVIDES)
+                  .apply {
+                    when (diFramework) {
+                      DiFramework.METRO -> addAnnotation(METRO_PROVIDES)
+                      DiFramework.HILT, DiFramework.DAGGER -> addAnnotation(DAGGER_PROVIDES)
+                      else -> {}
+                    }
+                  }
                   .addParameter(
                     "databaseBuilder",
                     ClassName(
@@ -128,12 +162,25 @@ class StitchModuleOutputWriter(
                       @see [${database.type.shortName}]
                         """.trimIndent(),
                       )
-                      .addAnnotation(
-                        AnnotationSpec.builder(METRO_SINGLE_IN)
-                          .addMember("%T::class", STITCH_SCOPE)
-                          .build(),
-                      )
-                      .addAnnotation(METRO_PROVIDES)
+                      .apply {
+                        when (diFramework) {
+                          DiFramework.METRO -> {
+                            addAnnotation(
+                              AnnotationSpec.builder(METRO_SINGLE_IN)
+                                .addMember("%T::class", STITCH_SCOPE)
+                                .build(),
+                            )
+                            addAnnotation(METRO_PROVIDES)
+                          }
+
+                          DiFramework.HILT, DiFramework.DAGGER -> {
+                            addAnnotation(JAVAX_SINGLETON)
+                            addAnnotation(DAGGER_PROVIDES)
+                          }
+
+                          else -> {}
+                        }
+                      }
                       .returns(
                         ClassName(
                           "${roomModel.packageName}.dao",
@@ -162,12 +209,25 @@ class StitchModuleOutputWriter(
                       @see [${roomModel.getRepositoryName()}]
                       """.trimIndent(),
                     )
-                    .addAnnotation(
-                      AnnotationSpec.builder(METRO_SINGLE_IN)
-                        .addMember("%T::class", STITCH_SCOPE)
-                        .build(),
-                    )
-                    .addAnnotation(METRO_PROVIDES)
+                    .apply {
+                      when (diFramework) {
+                        DiFramework.METRO -> {
+                          addAnnotation(
+                            AnnotationSpec.builder(METRO_SINGLE_IN)
+                              .addMember("%T::class", STITCH_SCOPE)
+                              .build(),
+                          )
+                          addAnnotation(METRO_PROVIDES)
+                        }
+
+                        DiFramework.HILT, DiFramework.DAGGER -> {
+                          addAnnotation(JAVAX_SINGLETON)
+                          addAnnotation(DAGGER_PROVIDES)
+                        }
+
+                        else -> {}
+                      }
+                    }
                     .returns(
                       ClassName(
                         roomModel.getRepositoryPackage(),

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -38,11 +38,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 
 public final class dev/teogor/stitch/StitchSchemaArgProvider : org/gradle/process/CommandLineArgumentProvider {
 	public static final field Companion Ldev/teogor/stitch/StitchSchemaArgProvider$Companion;
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
->>>>>>> feature/domain-mapping
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun asArguments ()Ljava/lang/Iterable;
 	public fun asArguments ()Ljava/util/List;
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -33,12 +33,9 @@ class StitchSchemaArgProvider(
   private val operationPackage: String?,
   private val diPackage: String?,
   private val enableMetro: Boolean,
-<<<<<<< HEAD
-  private val repositoryBaseClass: String?,
-=======
   private val diFramework: DiFramework,
   private val injectAnnotation: String?,
->>>>>>> feature/domain-mapping
+  private val repositoryBaseClass: String?,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -55,11 +52,8 @@ class StitchSchemaArgProvider(
     repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
     operationPackage?.let { "stitch.operationPackage=$it" },
     diPackage?.let { "stitch.diPackage=$it" },
-<<<<<<< HEAD
-    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
-=======
     injectAnnotation?.let { "stitch.injectAnnotation=$it" },
->>>>>>> feature/domain-mapping
+    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
   )
 
   companion object {
@@ -76,12 +70,9 @@ class StitchSchemaArgProvider(
       operationPackage = stitchExtension.operationPackage,
       diPackage = stitchExtension.diPackage,
       enableMetro = stitchExtension.enableMetro,
-<<<<<<< HEAD
-      repositoryBaseClass = stitchExtension.repositoryBaseClass,
-=======
       diFramework = stitchExtension.diFramework,
       injectAnnotation = stitchExtension.injectAnnotation,
->>>>>>> feature/domain-mapping
+      repositoryBaseClass = stitchExtension.repositoryBaseClass,
     )
   }
 }


### PR DESCRIPTION
This PR adds support for generating Dependency Injection modules for Hilt and Dagger, extending the existing Metro support.

### Changes:
- Added constants for Hilt and Dagger annotations in .
- Updated  to handle  and .
- For Hilt, the generated module is annotated with  and .
- For Dagger, the generated module is annotated with .
- Updated  to correctly pass DI arguments and cleaned up unresolved merge conflict markers in the process.
- Re-generated API dumps to reflect changes and clear previous conflict markers.

### DI Framework Specifics:
- **Hilt**: Uses  scope for provided DAOs and Repositories.
- **Dagger**: Uses standard  methods within the module.
- **Metro**: Remains unchanged, using its specific annotations.