### PR TITLE
feat(codegen): implement granular naming control with @StitchName

### DIFF
--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
@@ -30,6 +30,8 @@ data class RoomModel(
   val packageName: String,
   val entity: TypeName,
   val mapTo: TypeName? = null,
+  val repositoryName: String? = null,
+  val repositoryImplName: String? = null,
   val dao: TypeName? = null,
   val fields: List<FieldKind>,
   val functions: List<FunctionKind>,

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/OutputWriter.kt
@@ -41,9 +41,9 @@ abstract class OutputWriter(
   fun RoomModel.getDiPackage() = codeGenConfig.diPackage
     ?: "${getBasePackage()}.di"
 
-  fun RoomModel.getRepositoryName() = "$name${codeGenConfig.repositorySuffix}"
+  fun RoomModel.getRepositoryName() = repositoryName ?: "$name${codeGenConfig.repositorySuffix}"
 
-  fun RoomModel.getRepositoryImplName() = "${getRepositoryName()}Impl"
+  fun RoomModel.getRepositoryImplName() = repositoryImplName ?: "${getRepositoryName()}Impl"
 
   fun RoomModel.getOperationName(baseName: String) =
     "$name${baseName.titleCase()}${codeGenConfig.operationSuffix}"

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/StitchName.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/StitchName.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch
+
+/**
+ * Annotation for providing custom names for generated repositories and their implementations.
+ *
+ * When applied to a Room DAO, Stitch will use the specified [repository] and [implementation]
+ * names instead of the default generated ones.
+ *
+ * @property repository The custom name for the generated repository interface.
+ * @property implementation The custom name for the generated repository implementation class.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class StitchName(
+  val repository: String = "",
+  val implementation: String = "",
+)

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -33,12 +33,9 @@ class StitchSchemaArgProvider(
   private val operationPackage: String?,
   private val diPackage: String?,
   private val enableMetro: Boolean,
-<<<<<<< HEAD
-  private val repositoryBaseClass: String?,
-=======
   private val diFramework: DiFramework,
   private val injectAnnotation: String?,
->>>>>>> feature/domain-mapping
+  private val repositoryBaseClass: String?,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -55,11 +52,8 @@ class StitchSchemaArgProvider(
     repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
     operationPackage?.let { "stitch.operationPackage=$it" },
     diPackage?.let { "stitch.diPackage=$it" },
-<<<<<<< HEAD
-    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
-=======
     injectAnnotation?.let { "stitch.injectAnnotation=$it" },
->>>>>>> feature/domain-mapping
+    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
   )
 
   companion object {
@@ -76,12 +70,9 @@ class StitchSchemaArgProvider(
       operationPackage = stitchExtension.operationPackage,
       diPackage = stitchExtension.diPackage,
       enableMetro = stitchExtension.enableMetro,
-<<<<<<< HEAD
-      repositoryBaseClass = stitchExtension.repositoryBaseClass,
-=======
       diFramework = stitchExtension.diFramework,
       injectAnnotation = stitchExtension.injectAnnotation,
->>>>>>> feature/domain-mapping
+      repositoryBaseClass = stitchExtension.repositoryBaseClass,
     )
   }
 }

--- a/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/processors/RoomModelMapper.kt
+++ b/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/processors/RoomModelMapper.kt
@@ -41,6 +41,7 @@ import dev.teogor.stitch.ExplicitEntities
 import dev.teogor.stitch.MapTo
 import dev.teogor.stitch.RawOperation
 import dev.teogor.stitch.StitchIgnore
+import dev.teogor.stitch.StitchName
 import dev.teogor.stitch.codegen.commons.findCommonBase
 import dev.teogor.stitch.codegen.commons.getCommonBase
 import dev.teogor.stitch.codegen.model.FieldKind
@@ -92,6 +93,14 @@ class RoomModelMapper(
     }
 
     if (dao == null || dao.isAnnotationPresent(StitchIgnore::class)) return null
+
+    val stitchNameAnnotation = dao.firstAnnotation<StitchName>()
+    val repositoryName = stitchNameAnnotation?.findArgumentValue<String>("repository")?.let {
+      if (it.isEmpty()) null else it
+    }
+    val repositoryImplName = stitchNameAnnotation?.findArgumentValue<String>("implementation")?.let {
+      if (it.isEmpty()) null else it
+    }
 
     val mapToAnnotation = entity.firstAnnotation<MapTo>()
     val mapTo = mapToAnnotation?.findArgumentValue<KSType>("target")?.toTypeName()
@@ -161,6 +170,8 @@ class RoomModelMapper(
       functions = functions,
       entity = entity.toClassName(),
       mapTo = mapTo,
+      repositoryName = repositoryName,
+      repositoryImplName = repositoryImplName,
       dao = dao.toClassName(),
     )
   }


### PR DESCRIPTION
This PR introduces the  annotation, allowing developers to override the default generated names for Repository interfaces and their implementations on a per-DAO basis.

### Changes:
- Added  annotation in the  module.
- Updated  in the  module to store optional custom repository and implementation names.
- Updated  in the  module to parse the  annotation when applied to a DAO.
- Modified  helper methods to respect these custom names during code generation.
- Cleaned up unresolved merge conflict markers in .

### Usage:

In this example, Stitch will generate  and  instead of  and .