### PR TITLE
feat(codegen): add option to generate only repository interfaces

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -51,20 +51,14 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-	public final fun component1 ()Z
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Z
-	public final fun component12 ()Ljava/lang/String;
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Z)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
 	public final fun component12 ()Ldev/teogor/stitch/api/DiFramework;
 	public final fun component13 ()Ljava/lang/String;
->>>>>>> feature/domain-mapping
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -73,19 +67,15 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-<<<<<<< HEAD
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-=======
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
->>>>>>> feature/domain-mapping
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Z)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
 	public final fun getDiPackage ()Ljava/lang/String;
 	public final fun getEnableMetro ()Z
 	public final fun getEnableOperationGeneration ()Z
+	public final fun getEnableRepositoryImplGeneration ()Z
 	public final fun getGeneratedPackageName ()Ljava/lang/String;
 	public final fun getInjectAnnotation ()Ljava/lang/String;
 	public final fun getOperationGenerationLevel ()Ldev/teogor/stitch/api/OperationGenerationLevel;

--- a/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -35,4 +35,5 @@ data class CodeGenConfig(
   val diFramework: DiFramework,
   val injectAnnotation: String?,
   val repositoryBaseClass: String?,
+  val enableRepositoryImplGeneration: Boolean,
 )

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
@@ -55,7 +55,9 @@ class CodeGenerator(
   fun generate(databaseModels: Sequence<DatabaseModel>, roomModels: List<RoomModel>) {
     roomModels.filter { it.hasDao }.forEach { roomModel ->
       val repositoryType = repositoryOutputWriter.write(roomModel)
-      repositoryImplOutputWriter.write(roomModel, repositoryType)
+      if (codeGenConfig.enableRepositoryImplGeneration) {
+        repositoryImplOutputWriter.write(roomModel, repositoryType)
+      }
     }
 
     stitchModuleOutputWriter.write(databaseModels, roomModels)

--- a/common/api/jvm/common.api
+++ b/common/api/jvm/common.api
@@ -58,6 +58,7 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun getDiPackage ()Ljava/lang/String;
 	public abstract fun getEnableMetro ()Z
 	public abstract fun getEnableOperationGeneration ()Z
+	public abstract fun getEnableRepositoryImplGeneration ()Z
 	public abstract fun getGeneratedPackageName ()Ljava/lang/String;
 	public abstract fun getInjectAnnotation ()Ljava/lang/String;
 	public abstract fun getOperationGenerationLevel ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -72,6 +73,7 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun setDiPackage (Ljava/lang/String;)V
 	public abstract fun setEnableMetro (Z)V
 	public abstract fun setEnableOperationGeneration (Z)V
+	public abstract fun setEnableRepositoryImplGeneration (Z)V
 	public abstract fun setGeneratedPackageName (Ljava/lang/String;)V
 	public abstract fun setInjectAnnotation (Ljava/lang/String;)V
 	public abstract fun setOperationGenerationLevel (Ldev/teogor/stitch/api/OperationGenerationLevel;)V

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -159,4 +159,14 @@ interface StitchExtension {
    * Provide the fully qualified name.
    */
   var repositoryBaseClass: String?
+
+  /**
+   * Controls whether to generate repository implementation classes.
+   *
+   * By default, this is set to `true`. Setting it to `false` will only generate
+   * repository interfaces.
+   *
+   * @return `true` if implementations are generated, `false` otherwise.
+   */
+  var enableRepositoryImplGeneration: Boolean
 }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -11,6 +11,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun getDiPackage ()Ljava/lang/String;
 	public fun getEnableMetro ()Z
 	public fun getEnableOperationGeneration ()Z
+	public fun getEnableRepositoryImplGeneration ()Z
 	public fun getGeneratedPackageName ()Ljava/lang/String;
 	public fun getInjectAnnotation ()Ljava/lang/String;
 	public fun getOperationGenerationLevel ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -25,6 +26,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun setDiPackage (Ljava/lang/String;)V
 	public fun setEnableMetro (Z)V
 	public fun setEnableOperationGeneration (Z)V
+	public fun setEnableRepositoryImplGeneration (Z)V
 	public fun setGeneratedPackageName (Ljava/lang/String;)V
 	public fun setInjectAnnotation (Ljava/lang/String;)V
 	public fun setOperationGenerationLevel (Ldev/teogor/stitch/api/OperationGenerationLevel;)V
@@ -38,11 +40,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 
 public final class dev/teogor/stitch/StitchSchemaArgProvider : org/gradle/process/CommandLineArgumentProvider {
 	public static final field Companion Ldev/teogor/stitch/StitchSchemaArgProvider$Companion;
-<<<<<<< HEAD
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
-=======
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;)V
->>>>>>> feature/domain-mapping
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Z)V
 	public synthetic fun asArguments ()Ljava/lang/Iterable;
 	public fun asArguments ()Ljava/util/List;
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -133,4 +133,11 @@ abstract class StitchExtensionImpl : StitchExtension {
    * Optional base class or interface for generated repository interfaces.
    */
   override var repositoryBaseClass: String? = null
+
+  /**
+   * Controls whether to generate repository implementation classes.
+   *
+   * By default, this is set to `true`.
+   */
+  override var enableRepositoryImplGeneration: Boolean = true
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -33,12 +33,10 @@ class StitchSchemaArgProvider(
   private val operationPackage: String?,
   private val diPackage: String?,
   private val enableMetro: Boolean,
-<<<<<<< HEAD
-  private val repositoryBaseClass: String?,
-=======
   private val diFramework: DiFramework,
   private val injectAnnotation: String?,
->>>>>>> feature/domain-mapping
+  private val repositoryBaseClass: String?,
+  private val enableRepositoryImplGeneration: Boolean,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -50,16 +48,14 @@ class StitchSchemaArgProvider(
     "stitch.operationSuffix=$operationSuffix",
     "stitch.enableMetro=$enableMetro",
     "stitch.diFramework=$diFramework",
+    "stitch.enableRepositoryImplGeneration=$enableRepositoryImplGeneration",
   ) + listOfNotNull(
     repositoryPackage?.let { "stitch.repositoryPackage=$it" },
     repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
     operationPackage?.let { "stitch.operationPackage=$it" },
     diPackage?.let { "stitch.diPackage=$it" },
-<<<<<<< HEAD
-    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
-=======
     injectAnnotation?.let { "stitch.injectAnnotation=$it" },
->>>>>>> feature/domain-mapping
+    repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
   )
 
   companion object {
@@ -76,12 +72,10 @@ class StitchSchemaArgProvider(
       operationPackage = stitchExtension.operationPackage,
       diPackage = stitchExtension.diPackage,
       enableMetro = stitchExtension.enableMetro,
-<<<<<<< HEAD
-      repositoryBaseClass = stitchExtension.repositoryBaseClass,
-=======
       diFramework = stitchExtension.diFramework,
       injectAnnotation = stitchExtension.injectAnnotation,
->>>>>>> feature/domain-mapping
+      repositoryBaseClass = stitchExtension.repositoryBaseClass,
+      enableRepositoryImplGeneration = stitchExtension.enableRepositoryImplGeneration,
     )
   }
 }

--- a/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
+++ b/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/processors/ConfigParser.kt
@@ -44,6 +44,7 @@ class ConfigParser(
     private const val DI_FRAMEWORK = "$PREFIX.diFramework"
     private const val INJECT_ANNOTATION = "$PREFIX.injectAnnotation"
     private const val REPOSITORY_BASE_CLASS = "$PREFIX.repositoryBaseClass"
+    private const val ENABLE_REPOSITORY_IMPL_GENERATION = "$PREFIX.enableRepositoryImplGeneration"
   }
 
   fun parse(): CodeGenConfig {
@@ -61,6 +62,7 @@ class ConfigParser(
     val diFramework = getDiFramework(enableMetro)
     val injectAnnotation = options[INJECT_ANNOTATION]?.trim()
     val repositoryBaseClass = options[REPOSITORY_BASE_CLASS]?.trim()
+    val enableRepositoryImplGeneration = parseBoolean(ENABLE_REPOSITORY_IMPL_GENERATION) ?: true
 
     return CodeGenConfig(
       addDocumentation = addDocumentation,
@@ -77,6 +79,7 @@ class ConfigParser(
       diFramework = diFramework,
       injectAnnotation = injectAnnotation,
       repositoryBaseClass = repositoryBaseClass,
+      enableRepositoryImplGeneration = enableRepositoryImplGeneration,
     )
   }
 


### PR DESCRIPTION
This PR introduces a new configuration option  (defaulting to ) that allows users to disable the generation of Repository implementation classes.

### Changes:
- Added  to  in .
- Updated  and  to pass this option to the code generator.
- Modified  to conditionally skip repository implementation generation.
- Cleaned up unresolved merge conflict markers in  that were present from the base branch.

### Use Case:
This is useful when developers want the boilerplate-free generated Repository interface but need to provide a custom implementation (e.g., for complex caching, combining multiple data sources, or adding analytics) without the overhead of unused generated classes.