### PR TITLE
feat(codegen): add ioDispatcherName to CodeGenConfig

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -56,7 +56,8 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZ)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
@@ -66,6 +67,7 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component15 ()Ldev/teogor/stitch/api/Visibility;
 	public final fun component16 ()Z
 	public final fun component17 ()Z
+	public final fun component18 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -74,8 +76,8 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZ)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
@@ -86,6 +88,7 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun getEnableRepositoryImplGeneration ()Z
 	public final fun getGeneratedPackageName ()Ljava/lang/String;
 	public final fun getInjectAnnotation ()Ljava/lang/String;
+	public final fun getIoDispatcherName ()Ljava/lang/String;
 	public final fun getOperationGenerationLevel ()Ldev/teogor/stitch/api/OperationGenerationLevel;
 	public final fun getOperationPackage ()Ljava/lang/String;
 	public final fun getOperationSuffix ()Ljava/lang/String;

--- a/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -39,4 +39,5 @@ data class CodeGenConfig(
   val visibility: Visibility,
   val enableRepositoryImplGeneration: Boolean,
   val enableKmpSupport: Boolean,
+  val ioDispatcherName: String? = null,
 )


### PR DESCRIPTION
This PR adds the  property to  to allow customization of the injected dispatcher's name in generated modules.