### PR TITLE
feat(codegen): add support for suspending mappers

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -184,22 +184,24 @@ public final class dev/teogor/stitch/codegen/model/ParameterKind {
 }
 
 public final class dev/teogor/stitch/codegen/model/RoomModel {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZLjava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZLjava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/squareup/kotlinpoet/TypeName;
-	public final fun component11 ()Ljava/util/List;
-	public final fun component12 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Lcom/squareup/kotlinpoet/TypeName;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/squareup/kotlinpoet/TypeName;
 	public final fun component4 ()Lcom/squareup/kotlinpoet/TypeName;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/squareup/kotlinpoet/TypeName;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;)Ldev/teogor/stitch/codegen/model/RoomModel;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/RoomModel;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/RoomModel;
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZLjava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;)Ldev/teogor/stitch/codegen/model/RoomModel;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/RoomModel;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;Ljava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;ZZLjava/lang/String;Ljava/lang/String;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/RoomModel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDao ()Lcom/squareup/kotlinpoet/TypeName;
 	public final fun getEntity ()Lcom/squareup/kotlinpoet/TypeName;
@@ -215,6 +217,8 @@ public final class dev/teogor/stitch/codegen/model/RoomModel {
 	public final fun getToDomain ()Ljava/lang/String;
 	public final fun getToEntity ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun isToDomainSuspend ()Z
+	public final fun isToEntitySuspend ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
@@ -33,6 +33,8 @@ data class RoomModel(
   val toDomain: String = "toDomain",
   val toEntity: String = "toEntity",
   val mapper: TypeName? = null,
+  val isToDomainSuspend: Boolean = false,
+  val isToEntitySuspend: Boolean = false,
   val repositoryName: String? = null,
   val repositoryImplName: String? = null,
   val dao: TypeName? = null,

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
@@ -45,6 +45,10 @@ class RepositoryImplOutputWriter(
     ) {
       if (roomModel.functions.any { it.returnType != it.returnType.mapTo(roomModel) }) {
         addImport("kotlinx.coroutines.flow", "map")
+        if (roomModel.isToDomainSuspend) {
+          addImport("kotlinx.coroutines.flow", "asFlow")
+          addImport("kotlinx.coroutines.flow", "toList")
+        }
       }
       addType(
         TypeSpec.classBuilder(repositoryImplName)
@@ -144,19 +148,16 @@ class RepositoryImplOutputWriter(
                       }
                     }
                     val invokeCode = "dao.${function.name}($args)"
+                    val (mappingCode, isMappingSuspend) = generateMappingCode(
+                      function.returnType,
+                      returnType,
+                      invokeCode,
+                      roomModel,
+                    )
                     if (returnType != UNIT) {
                       returns(returnType)
                       if (function.returnType != returnType) {
-                        addCode(
-                          "return ${
-                            generateMappingCode(
-                              function.returnType,
-                              returnType,
-                              invokeCode,
-                              roomModel,
-                            )
-                          }",
-                        )
+                        addCode("return $mappingCode")
                       } else {
                         addCode("return $invokeCode")
                       }
@@ -166,7 +167,12 @@ class RepositoryImplOutputWriter(
                     function.parameters.forEach { parameter ->
                       addParameter(parameter.name, parameter.type.mapTo(roomModel))
                     }
-                    if (function.isSuspend) {
+                    val isAnyParamMappingSuspend = function.parameters.any { parameter ->
+                      parameter.type != parameter.type.mapTo(
+                        roomModel,
+                      ) && roomModel.isToEntitySuspend
+                    }
+                    if (function.isSuspend || isMappingSuspend || isAnyParamMappingSuspend) {
                       addModifiers(KModifier.SUSPEND)
                     }
                   }
@@ -184,11 +190,13 @@ class RepositoryImplOutputWriter(
     targetType: TypeName,
     expression: String,
     roomModel: RoomModel,
-  ): String {
-    if (sourceType == targetType) return expression
+    usedNames: Set<String> = emptySet(),
+  ): Pair<String, Boolean> {
+    if (sourceType == targetType) return expression to false
 
     val toDomain = roomModel.toDomain
     val mapper = roomModel.mapper
+    val isToDomainSuspend = roomModel.isToDomainSuspend
 
     if (sourceType is ParameterizedTypeName && targetType is ParameterizedTypeName) {
       val rawSource = sourceType.rawType
@@ -196,15 +204,39 @@ class RepositoryImplOutputWriter(
       if (rawSource == rawTarget) {
         val sourceArg = sourceType.typeArguments[0]
         val targetArg = targetType.typeArguments[0]
-        val mapping = generateMappingCode(sourceArg, targetArg, "it", roomModel)
-        return "$expression.map { $mapping }"
+
+        var paramName = if (sourceArg is ParameterizedTypeName && sourceArg.rawType.simpleName == "List") {
+          "list"
+        } else {
+          "item"
+        }
+
+        if (usedNames.contains(paramName)) {
+          paramName += usedNames.size
+        }
+
+        val (mapping, isInnerSuspend) = generateMappingCode(
+          sourceArg,
+          targetArg,
+          paramName,
+          roomModel,
+          usedNames + paramName,
+        )
+
+        return if (rawSource.simpleName == "List" && isInnerSuspend) {
+          ("$expression.asFlow().map { $paramName -> $mapping }.toList()") to true
+        } else if (rawSource.simpleName == "Flow") {
+          ("$expression.map { $paramName -> $mapping }") to false
+        } else {
+          ("$expression.map { $paramName -> $mapping }") to isInnerSuspend
+        }
       }
     }
 
     return if (mapper != null) {
-      "mapper.$toDomain($expression)"
+      "mapper.$toDomain($expression)" to isToDomainSuspend
     } else {
-      "$expression.$toDomain()"
+      "$expression.$toDomain()" to false
     }
   }
 }

--- a/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/processors/RoomModelMapper.kt
+++ b/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/processors/RoomModelMapper.kt
@@ -108,8 +108,24 @@ class RoomModelMapper(
     val mapTo = mapToAnnotation?.findArgumentValue<KSType>("target")?.toTypeName()
     val toDomain = mapToAnnotation?.findArgumentValue<String>("toDomain") ?: "toDomain"
     val toEntity = mapToAnnotation?.findArgumentValue<String>("toEntity") ?: "toEntity"
-    val mapper = mapToAnnotation?.findArgumentValue<KSType>("mapper")?.toTypeName()?.let {
+    val mapperType = mapToAnnotation?.findArgumentValue<KSType>("mapper")
+    val mapper = mapperType?.toTypeName()?.let {
       if (it.toString() == "kotlin.Nothing") null else it
+    }
+
+    var isToDomainSuspend = false
+    var isToEntitySuspend = false
+
+    mapperType?.declaration?.let { mapperDecl ->
+      if (mapperDecl is KSClassDeclaration) {
+        val mapperFunctions = mapperDecl.getDeclaredFunctions()
+        isToDomainSuspend = mapperFunctions.any {
+          it.simpleName.asString() == toDomain && it.modifiers.contains(Modifier.SUSPEND)
+        }
+        isToEntitySuspend = mapperFunctions.any {
+          it.simpleName.asString() == toEntity && it.modifiers.contains(Modifier.SUSPEND)
+        }
+      }
     }
 
     val fields = entity.primaryConstructor?.parameters?.map { parameter ->
@@ -180,6 +196,8 @@ class RoomModelMapper(
       toDomain = toDomain,
       toEntity = toEntity,
       mapper = mapper,
+      isToDomainSuspend = isToDomainSuspend,
+      isToEntitySuspend = isToEntitySuspend,
       repositoryName = repositoryName,
       repositoryImplName = repositoryImplName,
       dao = dao.toClassName(),


### PR DESCRIPTION
This PR adds support for suspending  and  functions in mappers. It updates KSP to detect these suspending functions and modifies the codegen to wrap mapping calls in the appropriate coroutine logic (e.g., using  for lists).