### PR TITLE
feat(codegen): add transactional DSL to repositories

### DIFF
--- a/app/src/main/kotlin/dev/teogor/stitch/MainActivity.kt
+++ b/app/src/main/kotlin/dev/teogor/stitch/MainActivity.kt
@@ -39,8 +39,8 @@ class MainActivity : ComponentActivity() {
         val db = remember { AppDatabase.getInstance(applicationContext) }
         val viewModel = remember {
           InventoryViewModel(
-            productRepository = InventoryProductRepositoryImpl(db.inventoryProductDao()),
-            categoryRepository = InventoryCategoryRepositoryImpl(db.inventoryCategoryDao()),
+            productRepository = InventoryProductRepositoryImpl(db.inventoryProductDao(), db),
+            categoryRepository = InventoryCategoryRepositoryImpl(db.inventoryCategoryDao(), db),
           )
         }
 

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -247,7 +247,7 @@ public abstract class dev/teogor/stitch/codegen/writers/OutputWriter {
 
 public final class dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter : dev/teogor/stitch/codegen/writers/OutputWriter {
 	public fun <init> (Ldev/teogor/stitch/codegen/facades/CodeOutputStreamMaker;Ldev/teogor/stitch/codegen/model/CodeGenConfig;)V
-	public final fun write (Ldev/teogor/stitch/codegen/model/RoomModel;Lcom/squareup/kotlinpoet/TypeName;)V
+	public final fun write (Ldev/teogor/stitch/codegen/model/RoomModel;Lcom/squareup/kotlinpoet/TypeName;Lcom/squareup/kotlinpoet/TypeName;)V
 }
 
 public final class dev/teogor/stitch/codegen/writers/RepositoryOutputWriter : dev/teogor/stitch/codegen/writers/OutputWriter {

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
@@ -63,7 +63,10 @@ class CodeGenerator(
     roomModels.filter { it.hasDao }.forEach { roomModel ->
       val repositoryType = repositoryOutputWriter.write(roomModel)
       if (codeGenConfig.enableRepositoryImplGeneration) {
-        repositoryImplOutputWriter.write(roomModel, repositoryType)
+        val database = databaseModels.firstOrNull {
+          it.entities.contains(roomModel.entity) || it.views.contains(roomModel.entity)
+        } ?: databaseModels.firstOrNull()
+        repositoryImplOutputWriter.write(roomModel, repositoryType, database?.type)
       }
     }
 

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryImplOutputWriter.kt
@@ -18,10 +18,12 @@ package dev.teogor.stitch.codegen.writers
 
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.UNIT
 import dev.teogor.stitch.codegen.commons.fileBuilder
 import dev.teogor.stitch.codegen.commons.mapTo
@@ -36,7 +38,7 @@ class RepositoryImplOutputWriter(
   codeGenConfig: CodeGenConfig,
 ) : OutputWriter(codeGenConfig) {
 
-  fun write(roomModel: RoomModel, repositoryType: TypeName) {
+  fun write(roomModel: RoomModel, repositoryType: TypeName, databaseType: TypeName?) {
     val repositoryImplName = roomModel.getRepositoryImplName()
     val repositoryImplPackage = roomModel.getRepositoryImplPackage()
     fileBuilder(
@@ -45,6 +47,10 @@ class RepositoryImplOutputWriter(
     ) {
       if (roomModel.functions.any { it.returnType != it.returnType.mapTo(roomModel) }) {
         addImport("kotlinx.coroutines.flow", "map")
+      }
+      if (databaseType != null) {
+        addImport("androidx.room3", "useWriterConnection")
+        addImport("androidx.room3", "immediateTransaction")
       }
       addType(
         TypeSpec.classBuilder(repositoryImplName)
@@ -69,8 +75,11 @@ class RepositoryImplOutputWriter(
           .apply {
             primaryConstructor(
               FunSpec.constructorBuilder()
-                .addParameter("dao", roomModel.dao)
+                .addParameter("dao", roomModel.dao!!)
                 .apply {
+                  databaseType?.let {
+                    addParameter("db", it)
+                  }
                   roomModel.mapper?.let { mapper ->
                     addParameter("mapper", mapper)
                   }
@@ -83,6 +92,14 @@ class RepositoryImplOutputWriter(
                 .addModifiers(KModifier.PRIVATE)
                 .build(),
             )
+            databaseType?.let {
+              addProperty(
+                PropertySpec.builder("db", it)
+                  .initializer("db")
+                  .addModifiers(KModifier.PRIVATE)
+                  .build(),
+              )
+            }
             roomModel.mapper?.let { mapper ->
               addProperty(
                 PropertySpec.builder("mapper", mapper)
@@ -170,6 +187,35 @@ class RepositoryImplOutputWriter(
                       addModifiers(KModifier.SUSPEND)
                     }
                   }
+                  .build(),
+              )
+            }
+
+            if (databaseType != null) {
+              addFunction(
+                FunSpec.builder("transaction")
+                  .addModifiers(KModifier.OVERRIDE)
+                  .addModifiers(KModifier.SUSPEND)
+                  .addTypeVariable(TypeVariableName("R"))
+                  .addParameter(
+                    "block",
+                    LambdaTypeName.get(
+                      receiver = repositoryType,
+                      returnType = TypeVariableName("R"),
+                    ).copy(suspending = true),
+                  )
+                  .returns(TypeVariableName("R"))
+                  .addDocumentation(
+                    """
+                    Executes the given block within a database transaction.
+
+                    @param block The block of code to execute within the transaction.
+                    @return The result of the transaction block.
+                    """.trimIndent(),
+                  )
+                  .addStatement(
+                    "return db.useWriterConnection { it.immediateTransaction { this@$repositoryImplName.block() } }",
+                  )
                   .build(),
               )
             }

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/RepositoryOutputWriter.kt
@@ -19,8 +19,10 @@ package dev.teogor.stitch.codegen.writers
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.UNIT
 import dev.teogor.stitch.codegen.commons.fileBuilder
 import dev.teogor.stitch.codegen.commons.mapTo
@@ -125,6 +127,30 @@ class RepositoryOutputWriter(
                   .build(),
               )
             }
+
+            addFunction(
+              FunSpec.builder("transaction")
+                .addModifiers(KModifier.ABSTRACT)
+                .addModifiers(KModifier.SUSPEND)
+                .addTypeVariable(TypeVariableName("R"))
+                .addParameter(
+                  "block",
+                  LambdaTypeName.get(
+                    receiver = ClassName(repositoryPackage, repositoryName),
+                    returnType = TypeVariableName("R"),
+                  ).copy(suspending = true),
+                )
+                .returns(TypeVariableName("R"))
+                .addDocumentation(
+                  """
+                  Executes the given block within a database transaction.
+
+                  @param block The block of code to execute within the transaction.
+                  @return The result of the transaction block.
+                  """.trimIndent(),
+                )
+                .build(),
+            )
           }
           .build(),
       )

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/StitchModuleOutputWriter.kt
@@ -245,6 +245,12 @@ ${roomModel.mapper?.let { "                      @param mapper The [${it.shortNa
                         ),
                       ).build(),
                     )
+                    .addParameter(
+                      ParameterSpec.builder(
+                        "db",
+                        database.type,
+                      ).build(),
+                    )
                     .apply {
                       roomModel.mapper?.let { mapper ->
                         addParameter(
@@ -256,7 +262,7 @@ ${roomModel.mapper?.let { "                      @param mapper The [${it.shortNa
                       }
                     }
                     .addStatement(
-                      "return %T(dao${if (roomModel.mapper != null) ", mapper" else ""})",
+                      "return %T(dao, db${if (roomModel.mapper != null) ", mapper" else ""})",
                       ClassName(
                         roomModel.getRepositoryImplPackage(),
                         roomModel.getRepositoryImplName(),


### PR DESCRIPTION
This PR adds a  method to the generated repository interfaces and implementations. It allows executing a block of code within a database transaction using Room\u0027s  and  (compatible with Room 3 KMP).