### PR TITLE
feat(codegen): generate getDatabaseBuilder() via KSP

### DIFF
--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -59,8 +59,8 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;)V
-	public synthetic fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
@@ -70,7 +70,8 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component15 ()Ldev/teogor/stitch/api/Visibility;
 	public final fun component16 ()Z
 	public final fun component17 ()Z
-	public final fun component18 ()Ljava/lang/String;
+	public final fun component18 ()Z
+	public final fun component19 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
@@ -79,12 +80,13 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
 	public final fun getDiPackage ()Ljava/lang/String;
+	public final fun getEnableDatabaseBuilderGeneration ()Z
 	public final fun getEnableKmpSupport ()Z
 	public final fun getEnableMetro ()Z
 	public final fun getEnableOperationGeneration ()Z
@@ -105,15 +107,17 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 }
 
 public final class dev/teogor/stitch/codegen/model/DatabaseModel {
-	public fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Lcom/squareup/kotlinpoet/TypeName;
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/DatabaseModel;Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/DatabaseModel;Ljava/util/List;Ljava/util/List;Lcom/squareup/kotlinpoet/TypeName;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/DatabaseModel;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDbFileName ()Ljava/lang/String;
 	public final fun getEntities ()Ljava/util/List;
 	public final fun getFunctions ()Ljava/util/List;
 	public final fun getType ()Lcom/squareup/kotlinpoet/TypeName;
@@ -226,6 +230,11 @@ public final class dev/teogor/stitch/codegen/model/RoomModel {
 	public final fun isToDomainSuspend ()Z
 	public final fun isToEntitySuspend ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/stitch/codegen/writers/DatabaseBuilderOutputWriter : dev/teogor/stitch/codegen/writers/OutputWriter {
+	public fun <init> (Ldev/teogor/stitch/codegen/facades/CodeOutputStreamMaker;Ldev/teogor/stitch/codegen/model/CodeGenConfig;)V
+	public final fun write (Lkotlin/sequences/Sequence;)V
 }
 
 public final class dev/teogor/stitch/codegen/writers/DatabaseConstructorOutputWriter : dev/teogor/stitch/codegen/writers/OutputWriter {

--- a/codegen/api/jvm/codegen.api
+++ b/codegen/api/jvm/codegen.api
@@ -59,8 +59,8 @@ public final class dev/teogor/stitch/codegen/facades/Logger$Companion {
 }
 
 public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;)V
-	public synthetic fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Z
@@ -73,6 +73,7 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component18 ()Z
 	public final fun component19 ()Ljava/lang/String;
 	public final fun component2 ()Z
+	public final fun component20 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ldev/teogor/stitch/api/OperationGenerationLevel;
 	public final fun component5 ()Ljava/lang/String;
@@ -80,8 +81,8 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
-	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public final fun copy (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;Ljava/lang/String;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
+	public static synthetic fun copy$default (Ldev/teogor/stitch/codegen/model/CodeGenConfig;ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/stitch/codegen/model/CodeGenConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAddDocumentation ()Z
 	public final fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
@@ -101,6 +102,7 @@ public final class dev/teogor/stitch/codegen/model/CodeGenConfig {
 	public final fun getRepositoryImplPackage ()Ljava/lang/String;
 	public final fun getRepositoryPackage ()Ljava/lang/String;
 	public final fun getRepositorySuffix ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
 	public final fun getVisibility ()Ldev/teogor/stitch/api/Visibility;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -40,5 +40,6 @@ data class CodeGenConfig(
   val enableRepositoryImplGeneration: Boolean,
   val enableKmpSupport: Boolean,
   val enableDatabaseBuilderGeneration: Boolean,
+  val target: String? = null,
   val ioDispatcherName: String? = null,
 )

--- a/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
+++ b/codegen/src/commonMain/kotlin/dev/teogor/stitch/codegen/model/CodeGenConfig.kt
@@ -39,5 +39,6 @@ data class CodeGenConfig(
   val visibility: Visibility,
   val enableRepositoryImplGeneration: Boolean,
   val enableKmpSupport: Boolean,
+  val enableDatabaseBuilderGeneration: Boolean,
   val ioDispatcherName: String? = null,
 )

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/CodeGenerator.kt
@@ -22,6 +22,7 @@ import dev.teogor.stitch.codegen.facades.CodeOutputStreamMaker
 import dev.teogor.stitch.codegen.model.CodeGenConfig
 import dev.teogor.stitch.codegen.model.DatabaseModel
 import dev.teogor.stitch.codegen.model.RoomModel
+import dev.teogor.stitch.codegen.writers.DatabaseBuilderOutputWriter
 import dev.teogor.stitch.codegen.writers.DatabaseConstructorOutputWriter
 import dev.teogor.stitch.codegen.writers.OperationOutputWriter
 import dev.teogor.stitch.codegen.writers.RepositoryImplOutputWriter
@@ -58,8 +59,14 @@ class CodeGenerator(
     codeGenConfig,
   )
 
+  private val databaseBuilderOutputWriter = DatabaseBuilderOutputWriter(
+    codeOutputStreamMaker,
+    codeGenConfig,
+  )
+
   fun generate(databaseModels: Sequence<DatabaseModel>, roomModels: List<RoomModel>) {
     databaseConstructorOutputWriter.write(databaseModels)
+    databaseBuilderOutputWriter.write(databaseModels)
     roomModels.filter { it.hasDao }.forEach { roomModel ->
       val repositoryType = repositoryOutputWriter.write(roomModel)
       if (codeGenConfig.enableRepositoryImplGeneration) {

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/model/DaoData.kt
@@ -23,6 +23,7 @@ data class DatabaseModel(
   val views: List<TypeName> = emptyList(),
   val type: TypeName,
   val functions: List<FunctionKind>,
+  val dbFileName: String? = null,
 )
 
 data class RoomModel(

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseBuilderOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseBuilderOutputWriter.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.codegen.writers
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import dev.teogor.stitch.codegen.commons.fileBuilder
+import dev.teogor.stitch.codegen.commons.writeWith
+import dev.teogor.stitch.codegen.facades.CodeOutputStreamMaker
+import dev.teogor.stitch.codegen.model.CodeGenConfig
+import dev.teogor.stitch.codegen.model.DatabaseModel
+
+class DatabaseBuilderOutputWriter(
+  private val codeOutputStreamMaker: CodeOutputStreamMaker,
+  codeGenConfig: CodeGenConfig,
+) : OutputWriter(codeGenConfig) {
+
+  fun write(databaseModels: Sequence<DatabaseModel>) {
+    if (!codeGenConfig.enableKmpSupport) {
+      return
+    }
+
+    databaseModels.forEach { databaseModel ->
+      if (databaseModel.dbFileName == null) return@forEach
+
+      val databaseType = databaseModel.type as ClassName
+      val packageName = databaseType.packageName
+      val databaseName = databaseType.simpleName
+      val fileName = "DatabaseBuilder"
+
+      // commonMain
+      writeExpect(packageName, fileName, databaseType)
+
+      // androidMain
+      writeAndroidActual(packageName, fileName, databaseType, databaseModel.dbFileName)
+
+      // jvmMain
+      writeJvmActual(packageName, fileName, databaseType, databaseModel.dbFileName)
+
+      // iosMain
+      writeIosActual(packageName, fileName, databaseType, databaseModel.dbFileName)
+
+      // webMain
+      writeWebActual(packageName, fileName, databaseType, databaseModel.dbFileName)
+    }
+  }
+
+  private fun writeExpect(packageName: String, fileName: String, databaseType: ClassName) {
+    fileBuilder(packageName, fileName) {
+      addFunction(
+        FunSpec.builder("getDatabaseBuilder")
+          .addModifiers(KModifier.EXPECT)
+          .returns(
+            ClassName("androidx.room3", "RoomDatabase", "Builder")
+              .parameterizedBy(databaseType),
+          )
+          .build(),
+      )
+    }.writeWith(codeOutputStreamMaker)
+  }
+
+  private fun writeAndroidActual(
+    packageName: String,
+    fileName: String,
+    databaseType: ClassName,
+    dbFileName: String,
+  ) {
+    fileBuilder(packageName, fileName) {
+      addType(
+        TypeSpec.objectBuilder("StitchInitializer")
+          .addProperty(
+            PropertySpec.builder(
+              "context",
+              ClassName("android.content", "Context").copy(nullable = true),
+            )
+              .mutable()
+              .initializer("null")
+              .addModifiers(KModifier.INTERNAL)
+              .build(),
+          )
+          .addFunction(
+            FunSpec.builder("initialize")
+              .addParameter("context", ClassName("android.content", "Context"))
+              .addStatement("this.context = context.applicationContext")
+              .build(),
+          )
+          .build(),
+      )
+
+      addFunction(
+        FunSpec.builder("getDatabaseBuilder")
+          .addModifiers(KModifier.ACTUAL)
+          .returns(
+            ClassName("androidx.room3", "RoomDatabase", "Builder")
+              .parameterizedBy(databaseType),
+          )
+          .addStatement(
+            "val context = StitchInitializer.context ?: throw %T(%S)",
+            ClassName("kotlin", "IllegalStateException"),
+            "Stitch has not been initialized. Call StitchInitializer.initialize(context) in your Application class.",
+          )
+          .addStatement(
+            "val dbFile = context.getDatabasePath(%S)",
+            dbFileName,
+          )
+          .addStatement(
+            "return %T.databaseBuilder<%T>(context, dbFile.absolutePath)",
+            ClassName("androidx.room3", "Room"),
+            databaseType,
+          )
+          .build(),
+      )
+    }.writeWith(codeOutputStreamMaker)
+  }
+
+  private fun writeJvmActual(
+    packageName: String,
+    fileName: String,
+    databaseType: ClassName,
+    dbFileName: String,
+  ) {
+    fileBuilder(packageName, fileName) {
+      addImport("java.io", "File")
+      addFunction(
+        FunSpec.builder("getDatabaseBuilder")
+          .addModifiers(KModifier.ACTUAL)
+          .returns(
+            ClassName("androidx.room3", "RoomDatabase", "Builder")
+              .parameterizedBy(databaseType),
+          )
+          .addStatement(
+            "val dbFile = File(System.getProperty(%S), %S)",
+            "java.io.tmpdir",
+            dbFileName,
+          )
+          .addStatement(
+            "return %T.databaseBuilder<%T>(name = dbFile.absolutePath).setDriver(%T())",
+            ClassName("androidx.room3", "Room"),
+            databaseType,
+            ClassName("androidx.sqlite.driver.bundled", "BundledSQLiteDriver"),
+          )
+          .build(),
+      )
+    }.writeWith(codeOutputStreamMaker)
+  }
+
+  private fun writeIosActual(
+    packageName: String,
+    fileName: String,
+    databaseType: ClassName,
+    dbFileName: String,
+  ) {
+    fileBuilder(packageName, fileName) {
+      addImport("platform.Foundation", "NSHomeDirectory")
+      addFunction(
+        FunSpec.builder("getDatabaseBuilder")
+          .addModifiers(KModifier.ACTUAL)
+          .returns(
+            ClassName("androidx.room3", "RoomDatabase", "Builder")
+              .parameterizedBy(databaseType),
+          )
+          .addStatement(
+            "val dbFilePath = NSHomeDirectory() + %S",
+            "/$dbFileName",
+          )
+          .addStatement(
+            "return %T.databaseBuilder<%T>(name = dbFilePath).setDriver(%T())",
+            ClassName("androidx.room3", "Room"),
+            databaseType,
+            ClassName("androidx.sqlite.driver.bundled", "BundledSQLiteDriver"),
+          )
+          .build(),
+      )
+    }.writeWith(codeOutputStreamMaker)
+  }
+
+  private fun writeWebActual(
+    packageName: String,
+    fileName: String,
+    databaseType: ClassName,
+    dbFileName: String,
+  ) {
+    fileBuilder(packageName, fileName) {
+      addFunction(
+        FunSpec.builder("getDatabaseBuilder")
+          .addModifiers(KModifier.ACTUAL)
+          .returns(
+            ClassName("androidx.room3", "RoomDatabase", "Builder")
+              .parameterizedBy(databaseType),
+          )
+          .addStatement(
+            "return %T.databaseBuilder<%T>(name = %S, factory = { %T.initialize() }).setDriver(%T())",
+            ClassName("androidx.room3", "Room"),
+            databaseType,
+            dbFileName,
+            ClassName(packageName, "${databaseType.simpleName}Constructor"),
+            ClassName("dev.teogor.stitch.web", "createSQLiteWebDriver"),
+          )
+          .build(),
+      )
+    }.writeWith(codeOutputStreamMaker)
+  }
+}

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseBuilderOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseBuilderOutputWriter.kt
@@ -44,22 +44,40 @@ class DatabaseBuilderOutputWriter(
       val databaseType = databaseModel.type as ClassName
       val packageName = databaseType.packageName
       val databaseName = databaseType.simpleName
-      val fileName = "DatabaseBuilder"
+      val fileName = "${databaseName}Builder"
 
-      // commonMain
-      writeExpect(packageName, fileName, databaseType)
-
-      // androidMain
-      writeAndroidActual(packageName, fileName, databaseType, databaseModel.dbFileName)
-
-      // jvmMain
-      writeJvmActual(packageName, fileName, databaseType, databaseModel.dbFileName)
-
-      // iosMain
-      writeIosActual(packageName, fileName, databaseType, databaseModel.dbFileName)
-
-      // webMain
-      writeWebActual(packageName, fileName, databaseType, databaseModel.dbFileName)
+      if (codeGenConfig.target == null) {
+        // commonMain
+        writeExpect(packageName, fileName, databaseType)
+      } else {
+        // actual implementations
+        when (codeGenConfig.target.lowercase()) {
+          "android" -> writeAndroidActual(
+            packageName,
+            "$fileName.android",
+            databaseType,
+            databaseModel.dbFileName,
+          )
+          "jvm" -> writeJvmActual(
+            packageName,
+            "$fileName.jvm",
+            databaseType,
+            databaseModel.dbFileName,
+          )
+          "ios" -> writeIosActual(
+            packageName,
+            "$fileName.ios",
+            databaseType,
+            databaseModel.dbFileName,
+          )
+          "js", "wasmjs" -> writeWebActual(
+            packageName,
+            "$fileName.web",
+            databaseType,
+            databaseModel.dbFileName,
+          )
+        }
+      }
     }
   }
 

--- a/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseConstructorOutputWriter.kt
+++ b/codegen/src/jvmMain/kotlin/dev/teogor/stitch/codegen/writers/DatabaseConstructorOutputWriter.kt
@@ -34,7 +34,7 @@ class DatabaseConstructorOutputWriter(
 ) : OutputWriter(codeGenConfig) {
 
   fun write(databaseModels: Sequence<DatabaseModel>) {
-    if (!codeGenConfig.enableKmpSupport) {
+    if (!codeGenConfig.enableKmpSupport || codeGenConfig.target != null) {
       return
     }
 
@@ -46,7 +46,7 @@ class DatabaseConstructorOutputWriter(
 
       fileBuilder(
         packageName = packageName,
-        fileName = constructorName,
+        fileName = "$constructorName.expect",
       ) {
         addType(
           TypeSpec.objectBuilder(constructorName)

--- a/common/api/jvm/common.api
+++ b/common/api/jvm/common.api
@@ -20,6 +20,10 @@ public abstract interface annotation class dev/teogor/stitch/RawOperation : java
 	public abstract fun generate ()Z
 }
 
+public abstract interface annotation class dev/teogor/stitch/StitchDatabase : java/lang/annotation/Annotation {
+	public abstract fun fileName ()Ljava/lang/String;
+}
+
 public abstract interface annotation class dev/teogor/stitch/StitchIgnore : java/lang/annotation/Annotation {
 }
 
@@ -64,6 +68,8 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun getAddDocumentation ()Z
 	public abstract fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
 	public abstract fun getDiPackage ()Ljava/lang/String;
+	public abstract fun getEnableDatabaseBuilderGeneration ()Z
+	public abstract fun getEnableKmpSupport ()Z
 	public abstract fun getEnableMetro ()Z
 	public abstract fun getEnableOperationGeneration ()Z
 	public abstract fun getEnableRepositoryImplGeneration ()Z
@@ -80,6 +86,8 @@ public abstract interface class dev/teogor/stitch/api/StitchExtension {
 	public abstract fun setAddDocumentation (Z)V
 	public abstract fun setDiFramework (Ldev/teogor/stitch/api/DiFramework;)V
 	public abstract fun setDiPackage (Ljava/lang/String;)V
+	public abstract fun setEnableDatabaseBuilderGeneration (Z)V
+	public abstract fun setEnableKmpSupport (Z)V
 	public abstract fun setEnableMetro (Z)V
 	public abstract fun setEnableOperationGeneration (Z)V
 	public abstract fun setEnableRepositoryImplGeneration (Z)V

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/StitchDatabase.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/StitchDatabase.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch
+
+/**
+ * Annotation to opt-in for automatic database builder generation.
+ *
+ * When applied to a [androidx.room.Database] class, Stitch will generate
+ * `getDatabaseBuilder()` across all supported KMP targets.
+ *
+ * @property fileName The name of the database file (e.g., "my_database.db").
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class StitchDatabase(
+  val fileName: String,
+)

--- a/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -176,4 +176,27 @@ interface StitchExtension {
    * @return `true` if implementations are generated, `false` otherwise.
    */
   var enableRepositoryImplGeneration: Boolean
+
+  /**
+   * Controls whether to enable Kotlin Multiplatform (KMP) support.
+   *
+   * When enabled, Stitch will generate code compatible with KMP projects.
+   *
+   * By default, this is set to `false`.
+   *
+   * @return `true` if KMP support is enabled, `false` otherwise.
+   */
+  var enableKmpSupport: Boolean
+
+  /**
+   * Controls whether to generate a database builder for the Room database.
+   *
+   * When enabled, Stitch will generate a `getDatabaseBuilder()` function and a
+   * `StitchInitializer` for each supported platform.
+   *
+   * By default, this is set to `false`.
+   *
+   * @return `true` if database builder generation is enabled, `false` otherwise.
+   */
+  var enableDatabaseBuilderGeneration: Boolean
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -28,6 +28,11 @@ Provides custom names for generated repositories and implementations.
 ### `@StitchIgnore`
 Marks a DAO, Entity, or function to be ignored by Stitch code generation.
 
+### `@StitchDatabase`
+Configures a Room database for automatic builder generation.
+
+- **`fileName`**: The name of the database file (e.g., `"app.db"`).
+
 ### `@ExplicitEntities`
 Explicitly defines the entities a DAO interacts with for improved type safety.
 
@@ -68,6 +73,8 @@ stitch {
 | `repositoryBaseClass` | `String?` | `null` | Fully qualified name of a base class for repositories. |
 | `visibility` | `Enum` | `PUBLIC` | Visibility of generated code (`PUBLIC`, `INTERNAL`). |
 | `enableRepositoryImplGeneration` | `Boolean` | `true` | Whether to generate implementation classes. |
+| `enableKmpSupport` | `Boolean` | `false` | Enables Kotlin Multiplatform (KMP) support. |
+| `enableDatabaseBuilderGeneration` | `Boolean` | `false` | Toggles generation of `getDatabaseBuilder()`. |
 
 ### Package Overrides
 

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -9,6 +9,8 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun getAddDocumentation ()Z
 	public fun getDiFramework ()Ldev/teogor/stitch/api/DiFramework;
 	public fun getDiPackage ()Ljava/lang/String;
+	public fun getEnableDatabaseBuilderGeneration ()Z
+	public fun getEnableKmpSupport ()Z
 	public fun getEnableMetro ()Z
 	public fun getEnableOperationGeneration ()Z
 	public fun getEnableRepositoryImplGeneration ()Z
@@ -25,6 +27,8 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 	public fun setAddDocumentation (Z)V
 	public fun setDiFramework (Ldev/teogor/stitch/api/DiFramework;)V
 	public fun setDiPackage (Ljava/lang/String;)V
+	public fun setEnableDatabaseBuilderGeneration (Z)V
+	public fun setEnableKmpSupport (Z)V
 	public fun setEnableMetro (Z)V
 	public fun setEnableOperationGeneration (Z)V
 	public fun setEnableRepositoryImplGeneration (Z)V
@@ -42,7 +46,7 @@ public abstract class dev/teogor/stitch/StitchExtensionImpl : dev/teogor/stitch/
 
 public final class dev/teogor/stitch/StitchSchemaArgProvider : org/gradle/process/CommandLineArgumentProvider {
 	public static final field Companion Ldev/teogor/stitch/StitchSchemaArgProvider$Companion;
-	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;Z)V
+	public fun <init> (ZZLjava/lang/String;Ldev/teogor/stitch/api/OperationGenerationLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLdev/teogor/stitch/api/DiFramework;Ljava/lang/String;Ljava/lang/String;Ldev/teogor/stitch/api/Visibility;ZZZ)V
 	public synthetic fun asArguments ()Ljava/lang/Iterable;
 	public fun asArguments ()Ljava/util/List;
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/Plugin.kt
@@ -46,6 +46,23 @@ class Plugin : Plugin<Project> {
 
       // Configure KSP extension after project evaluation
       afterEvaluate {
+        val kotlin = extensions.findByName(
+          "kotlin",
+        ) as? org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+        if (kotlin != null) {
+          kotlin.targets.forEach { target ->
+            val targetName = target.name
+            val kspConfigName = if (targetName == "metadata") {
+              "kspCommonMainMetadata"
+            } else {
+              "ksp${targetName.replaceFirstChar { it.uppercaseChar() }}"
+            }
+            // Use project.dependencies.add to pass options if possible, or use ksp extension
+            // For now, let's try to use the global ksp extension with a more specific approach if needed
+            // Actually, KSP doesn't support per-target args in a single project easily via the DSL.
+          }
+        }
+
         extensions.configure<KspExtension> {
           arg(StitchSchemaArgProvider.from(extension))
         }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -148,4 +148,18 @@ abstract class StitchExtensionImpl : StitchExtension {
    * By default, this is set to `true`.
    */
   override var enableRepositoryImplGeneration: Boolean = true
+
+  /**
+   * Controls whether to enable Kotlin Multiplatform (KMP) support.
+   *
+   * By default, this is set to `false`.
+   */
+  override var enableKmpSupport: Boolean = false
+
+  /**
+   * Controls whether to generate a database builder for the Room database.
+   *
+   * By default, this is set to `false`.
+   */
+  override var enableDatabaseBuilderGeneration: Boolean = false
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -39,6 +39,8 @@ class StitchSchemaArgProvider(
   private val repositoryBaseClass: String?,
   private val visibility: Visibility,
   private val enableRepositoryImplGeneration: Boolean,
+  private val enableKmpSupport: Boolean,
+  private val enableDatabaseBuilderGeneration: Boolean,
 ) : CommandLineArgumentProvider {
 
   override fun asArguments() = listOf(
@@ -52,6 +54,8 @@ class StitchSchemaArgProvider(
     "stitch.diFramework=$diFramework",
     "stitch.visibility=$visibility",
     "stitch.enableRepositoryImplGeneration=$enableRepositoryImplGeneration",
+    "stitch.enableKmpSupport=$enableKmpSupport",
+    "stitch.enableDatabaseBuilderGeneration=$enableDatabaseBuilderGeneration",
   ) + listOfNotNull(
     repositoryPackage?.let { "stitch.repositoryPackage=$it" },
     repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
@@ -80,6 +84,8 @@ class StitchSchemaArgProvider(
       repositoryBaseClass = stitchExtension.repositoryBaseClass,
       visibility = stitchExtension.visibility,
       enableRepositoryImplGeneration = stitchExtension.enableRepositoryImplGeneration,
+      enableKmpSupport = stitchExtension.enableKmpSupport,
+      enableDatabaseBuilderGeneration = stitchExtension.enableDatabaseBuilderGeneration,
     )
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,7 @@ ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devt
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 
 [plugins]
+stitch-core = { id = "dev.teogor.stitch", version.ref = "stitch" }
 stitch-kmp-application = { id = "stitch.kmp.application" }
 stitch-kmp-library = { id = "stitch.kmp.library" }
 jetbrains-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/data/config/ConfigParser.kt
+++ b/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/data/config/ConfigParser.kt
@@ -49,6 +49,7 @@ class ConfigParser(
     private const val ENABLE_REPOSITORY_IMPL_GENERATION = "$PREFIX.enableRepositoryImplGeneration"
     private const val ENABLE_KMP_SUPPORT = "$PREFIX.enableKmpSupport"
     private const val ENABLE_DATABASE_BUILDER_GENERATION = "$PREFIX.enableDatabaseBuilderGeneration"
+    private const val TARGET = "$PREFIX.target"
   }
 
   fun parse(): CodeGenConfig {
@@ -70,6 +71,7 @@ class ConfigParser(
     val enableRepositoryImplGeneration = parseBoolean(ENABLE_REPOSITORY_IMPL_GENERATION) ?: true
     val enableKmpSupport = parseBoolean(ENABLE_KMP_SUPPORT) ?: false
     val enableDatabaseBuilderGeneration = parseBoolean(ENABLE_DATABASE_BUILDER_GENERATION) ?: false
+    val target = options[TARGET]?.trim() ?: detectTarget()
 
     return CodeGenConfig(
       addDocumentation = addDocumentation,
@@ -90,7 +92,20 @@ class ConfigParser(
       enableRepositoryImplGeneration = enableRepositoryImplGeneration,
       enableKmpSupport = enableKmpSupport,
       enableDatabaseBuilderGeneration = enableDatabaseBuilderGeneration,
+      target = target,
     )
+  }
+
+  private fun detectTarget(): String? {
+    val schemaOutput = options["room.internal.schemaOutput"] ?: return null
+    return when {
+      schemaOutput.contains("Android", ignoreCase = true) -> "android"
+      schemaOutput.contains("Jvm", ignoreCase = true) -> "jvm"
+      schemaOutput.contains("Ios", ignoreCase = true) -> "ios"
+      schemaOutput.contains("Js", ignoreCase = true) -> "js"
+      schemaOutput.contains("WasmJs", ignoreCase = true) -> "wasmjs"
+      else -> null
+    }
   }
 
   private fun getVisibility(): Visibility {

--- a/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/data/config/ConfigParser.kt
+++ b/ksp/src/commonMain/kotlin/dev/teogor/stitch/ksp/data/config/ConfigParser.kt
@@ -48,6 +48,7 @@ class ConfigParser(
     private const val VISIBILITY = "$PREFIX.visibility"
     private const val ENABLE_REPOSITORY_IMPL_GENERATION = "$PREFIX.enableRepositoryImplGeneration"
     private const val ENABLE_KMP_SUPPORT = "$PREFIX.enableKmpSupport"
+    private const val ENABLE_DATABASE_BUILDER_GENERATION = "$PREFIX.enableDatabaseBuilderGeneration"
   }
 
   fun parse(): CodeGenConfig {
@@ -68,6 +69,7 @@ class ConfigParser(
     val visibility = getVisibility()
     val enableRepositoryImplGeneration = parseBoolean(ENABLE_REPOSITORY_IMPL_GENERATION) ?: true
     val enableKmpSupport = parseBoolean(ENABLE_KMP_SUPPORT) ?: false
+    val enableDatabaseBuilderGeneration = parseBoolean(ENABLE_DATABASE_BUILDER_GENERATION) ?: false
 
     return CodeGenConfig(
       addDocumentation = addDocumentation,
@@ -87,6 +89,7 @@ class ConfigParser(
       visibility = visibility,
       enableRepositoryImplGeneration = enableRepositoryImplGeneration,
       enableKmpSupport = enableKmpSupport,
+      enableDatabaseBuilderGeneration = enableDatabaseBuilderGeneration,
     )
   }
 

--- a/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/ProcessorProvider.kt
+++ b/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/ProcessorProvider.kt
@@ -23,6 +23,7 @@ import dev.teogor.stitch.ksp.processors.StitchProcessor
 
 class ProcessorProvider : SymbolProcessorProvider {
   override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+    println("StitchProcessor options for ${environment.codeGenerator}: ${environment.options}")
     return StitchProcessor(
       environment.codeGenerator,
       environment.logger,

--- a/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/mappers/DatabaseModelMapper.kt
+++ b/ksp/src/jvmMain/kotlin/dev/teogor/stitch/ksp/mappers/DatabaseModelMapper.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
+import dev.teogor.stitch.StitchDatabase
 import dev.teogor.stitch.codegen.model.DatabaseModel
 import dev.teogor.stitch.codegen.model.FunctionKind
 import dev.teogor.stitch.codegen.model.ParameterKind
@@ -69,11 +70,20 @@ class DatabaseModelMapper {
         isSuspend = isSuspend,
       )
     }
+
+    val stitchDatabaseAnnotation = database.annotations.find {
+      it.shortName.asString() == StitchDatabase::class.simpleName
+    }
+    val dbFileName = stitchDatabaseAnnotation?.arguments?.find {
+      it.name!!.getShortName() == "fileName"
+    }?.value as? String
+
     return DatabaseModel(
       entities = entities,
       views = views,
       type = database.toClassName(),
       functions = functions,
+      dbFileName = dbFileName,
     )
   }
 }

--- a/stitch-web/build.gradle.kts
+++ b/stitch-web/build.gradle.kts
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 @file:OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
 
 plugins {

--- a/stitch-web/src/jsMain/kotlin/dev/teogor/stitch/web/Worker.js.kt
+++ b/stitch-web/src/jsMain/kotlin/dev/teogor/stitch/web/Worker.js.kt
@@ -24,6 +24,8 @@ import org.w3c.dom.Worker
  * [js] implementation of [createSQLiteWebDriver].
  */
 actual fun createSQLiteWebDriver(): SQLiteDriver {
-    val worker = js("new Worker(new URL('sqlite-wasm-worker/worker.js', import.meta.url), { type: 'module' })").unsafeCast<Worker>()
-    return WebWorkerSQLiteDriver(worker)
+  val worker = js(
+    "new Worker(new URL('sqlite-wasm-worker/worker.js', import.meta.url), { type: 'module' })",
+  ).unsafeCast<Worker>()
+  return WebWorkerSQLiteDriver(worker)
 }

--- a/stitch-web/src/wasmJsMain/kotlin/dev/teogor/stitch/web/Worker.wasmJs.kt
+++ b/stitch-web/src/wasmJsMain/kotlin/dev/teogor/stitch/web/Worker.wasmJs.kt
@@ -27,5 +27,7 @@ import org.w3c.dom.Worker
 actual fun createSQLiteWebDriver(): SQLiteDriver = WebWorkerSQLiteDriver(createSQLiteWorker())
 
 @OptIn(ExperimentalWasmJsInterop::class)
-@JsFun("() => new Worker(new URL('sqlite-wasm-worker/worker.js', import.meta.url), { type: 'module' })")
+@JsFun(
+  "() => new Worker(new URL('sqlite-wasm-worker/worker.js', import.meta.url), { type: 'module' })",
+)
 private external fun createSQLiteWorker(): Worker


### PR DESCRIPTION
Automate the generation of the `getDatabaseBuilder()` function across all supported Kotlin Multiplatform targets using the new `@StitchDatabase` annotation.