### PR TITLE
feat(runtime): add withTransaction extension for RoomDatabase

### DIFF
--- a/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/data/repository/DemoRepositoryImpl.kt
+++ b/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/data/repository/DemoRepositoryImpl.kt
@@ -16,16 +16,19 @@
 
 package dev.teogor.stitch.catalog.demo.data.repository
 
+import dev.teogor.stitch.catalog.demo.data.local.AppDatabase
 import dev.teogor.stitch.catalog.demo.data.local.dao.DemoDao
 import dev.teogor.stitch.catalog.demo.data.local.entity.toDomain
 import dev.teogor.stitch.catalog.demo.data.local.entity.toEntity
 import dev.teogor.stitch.catalog.demo.domain.model.DemoModel
 import dev.teogor.stitch.catalog.demo.domain.repository.DemoRepository
+import dev.teogor.stitch.runtime.withTransaction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class DemoRepositoryImpl(
-  private val demoDao: DemoDao,
+  private val db: AppDatabase,
+  private val demoDao: DemoDao = db.demoDao(),
 ) : DemoRepository {
 
   override fun observeAll(): Flow<List<DemoModel>> {
@@ -40,6 +43,12 @@ class DemoRepositoryImpl(
 
   override suspend fun insert(item: DemoModel) {
     demoDao.insert(item.toEntity())
+  }
+
+  override suspend fun bulkInsert(items: List<DemoModel>) {
+    db.withTransaction {
+      items.forEach { insert(it) }
+    }
   }
 
   override suspend fun delete(item: DemoModel) {

--- a/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/di/DemoModule.kt
+++ b/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/di/DemoModule.kt
@@ -32,10 +32,8 @@ object DemoModule {
     ).build()
   }
 
-  private val demoDao by lazy { database.demoDao() }
-
   val demoRepository: DemoRepository by lazy {
-    DemoRepositoryImpl(demoDao)
+    DemoRepositoryImpl(database)
   }
 
   val getDemoItemsUseCase by lazy {

--- a/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/domain/repository/DemoRepository.kt
+++ b/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/domain/repository/DemoRepository.kt
@@ -23,5 +23,6 @@ interface DemoRepository {
   fun observeAll(): Flow<List<DemoModel>>
   suspend fun getById(id: Long): DemoModel?
   suspend fun insert(item: DemoModel)
+  suspend fun bulkInsert(items: List<DemoModel>)
   suspend fun delete(item: DemoModel)
 }

--- a/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/Extensions.kt
+++ b/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/Extensions.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.room3.RoomDatabase
+import androidx.room3.immediateTransaction
+import androidx.room3.useWriterConnection
+
+/**
+ * Wraps a block of code in a write transaction.
+ *
+ * This uses [useWriterConnection] and [immediateTransaction] internally
+ * to provide a familiar API for common code.
+ *
+ * @param block The block of code to execute within the transaction.
+ * @return The result of the transaction block.
+ */
+suspend fun <R> RoomDatabase.withTransaction(
+  block: suspend () -> R,
+): R = useWriterConnection { transactor ->
+  transactor.immediateTransaction {
+    block()
+  }
+}


### PR DESCRIPTION
This PR introduces a `withTransaction` extension function for `RoomDatabase` in the `stitch-runtime` module to simplify database transactions in Kotlin Multiplatform.\n\n### Changes\n- **stitch-runtime**: Added `withTransaction` extension for `RoomDatabase`.\n- **catalog**:\n  - Updated `DemoRepository` to support `bulkInsert`.\n  - Implemented `bulkInsert` using `withTransaction`.\n  - Refactored `DemoRepositoryImpl` to depend on `AppDatabase`.