### PR TITLE
Introduce SQL Query Logging Support

### DIFF
--- a/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/di/DemoModule.kt
+++ b/catalog/shared/src/commonMain/kotlin/dev/teogor/stitch/catalog/demo/di/DemoModule.kt
@@ -29,7 +29,10 @@ object DemoModule {
     StitchRoom.databaseBuilder(
       name = "demo_database.db",
       factory = AppDatabaseConstructor::initialize,
-    ).build()
+    ) {
+      loggingEnabled = true
+      logger = { println("DemoLog: $it") }
+    }.build()
   }
 
   val demoRepository: DemoRepository by lazy {

--- a/stitch-runtime/src/androidMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.android.kt
+++ b/stitch-runtime/src/androidMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.android.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.SQLiteStatement
+
+internal actual class LoggingSQLiteDriver actual constructor(
+  private val delegate: SQLiteDriver,
+  private val logger: (String) -> Unit,
+) : SQLiteDriver by delegate {
+  override fun open(fileName: String): SQLiteConnection {
+    return LoggingSQLiteConnection(delegate.open(fileName), logger)
+  }
+}
+
+internal actual class LoggingSQLiteConnection actual constructor(
+  private val delegate: SQLiteConnection,
+  private val logger: (String) -> Unit,
+) : SQLiteConnection by delegate {
+  override fun prepare(sql: String): SQLiteStatement {
+    return LoggingSQLiteStatement(sql, delegate.prepare(sql), logger)
+  }
+}
+
+internal actual class LoggingSQLiteStatement actual constructor(
+  private val sql: String,
+  private val delegate: SQLiteStatement,
+  private val logger: (String) -> Unit,
+) : SQLiteStatement by delegate {
+  private val bindings = mutableMapOf<Int, Any?>()
+  private var hasLogged = false
+
+  override fun bindBlob(index: Int, value: ByteArray) {
+    bindings[index] = "Blob(${value.size} bytes)"
+    delegate.bindBlob(index, value)
+  }
+
+  override fun bindDouble(index: Int, value: Double) {
+    bindings[index] = value
+    delegate.bindDouble(index, value)
+  }
+
+  override fun bindLong(index: Int, value: Long) {
+    bindings[index] = value
+    delegate.bindLong(index, value)
+  }
+
+  override fun bindText(index: Int, value: String) {
+    bindings[index] = value
+    delegate.bindText(index, value)
+  }
+
+  override fun bindNull(index: Int) {
+    bindings[index] = null
+    delegate.bindNull(index)
+  }
+
+  override fun bindBoolean(index: Int, value: Boolean) {
+    bindings[index] = value
+    delegate.bindBoolean(index, value)
+  }
+
+  override fun bindInt(index: Int, value: Int) {
+    bindings[index] = value
+    delegate.bindInt(index, value)
+  }
+
+  override fun bindFloat(index: Int, value: Float) {
+    bindings[index] = value
+    delegate.bindFloat(index, value)
+  }
+
+  override fun step(): Boolean {
+    if (!hasLogged) {
+      logger(formatLog(sql, bindings))
+      hasLogged = true
+    }
+    return delegate.step()
+  }
+
+  override fun reset() {
+    hasLogged = false
+    delegate.reset()
+  }
+
+  override fun clearBindings() {
+    bindings.clear()
+    delegate.clearBindings()
+  }
+}

--- a/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.kt
+++ b/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.SQLiteStatement
+
+/**
+ * A [SQLiteDriver] decorator that logs all executed SQL queries and their parameters.
+ */
+internal expect class LoggingSQLiteDriver(
+  delegate: SQLiteDriver,
+  logger: (String) -> Unit,
+) : SQLiteDriver
+
+/**
+ * A [SQLiteConnection] decorator that logs prepared SQL queries.
+ */
+internal expect class LoggingSQLiteConnection(
+  delegate: SQLiteConnection,
+  logger: (String) -> Unit,
+) : SQLiteConnection
+
+/**
+ * A [SQLiteStatement] decorator that logs the SQL query and its bound parameters when executed.
+ */
+internal expect class LoggingSQLiteStatement(
+  sql: String,
+  delegate: SQLiteStatement,
+  logger: (String) -> Unit,
+) : SQLiteStatement
+
+internal fun formatLog(sql: String, bindings: Map<Int, Any?>): String {
+  val formattedArgs = if (bindings.isEmpty()) {
+    ""
+  } else {
+    val sortedValues = bindings.keys.sorted().map { bindings[it] }
+    "\n  args: ${sortedValues.joinToString(", ")}"
+  }
+  return "SQLite: $sql$formattedArgs"
+}

--- a/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/StitchRoomConfig.kt
+++ b/stitch-runtime/src/commonMain/kotlin/dev/teogor/stitch/runtime/StitchRoomConfig.kt
@@ -56,6 +56,18 @@ class StitchRoomConfig<T : RoomDatabase> {
    */
   var journalMode: RoomDatabase.JournalMode = RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING
 
+  /**
+   * Whether to enable SQL query logging.
+   * If true, all executed SQL queries and their parameters will be logged using [logger].
+   */
+  var loggingEnabled: Boolean = false
+
+  /**
+   * The logger function used for SQL query logging.
+   * Defaults to printing to the console.
+   */
+  var logger: (String) -> Unit = { println(it) }
+
   private val migrations = mutableListOf<Migration>()
   private val callbacks = mutableListOf<RoomDatabase.Callback>()
   private val typeConverters = mutableListOf<Any>()
@@ -131,7 +143,12 @@ class StitchRoomConfig<T : RoomDatabase> {
     }
 
     sqliteDriver?.let {
-      builder.setDriver(it)
+      val finalDriver = if (loggingEnabled) {
+        LoggingSQLiteDriver(it, logger)
+      } else {
+        it
+      }
+      builder.setDriver(finalDriver)
     }
   }
 }

--- a/stitch-runtime/src/iosMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.ios.kt
+++ b/stitch-runtime/src/iosMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.ios.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.SQLiteStatement
+
+internal actual class LoggingSQLiteDriver actual constructor(
+  private val delegate: SQLiteDriver,
+  private val logger: (String) -> Unit,
+) : SQLiteDriver by delegate {
+  override fun open(fileName: String): SQLiteConnection {
+    return LoggingSQLiteConnection(delegate.open(fileName), logger)
+  }
+}
+
+internal actual class LoggingSQLiteConnection actual constructor(
+  private val delegate: SQLiteConnection,
+  private val logger: (String) -> Unit,
+) : SQLiteConnection by delegate {
+  override fun prepare(sql: String): SQLiteStatement {
+    return LoggingSQLiteStatement(sql, delegate.prepare(sql), logger)
+  }
+}
+
+internal actual class LoggingSQLiteStatement actual constructor(
+  private val sql: String,
+  private val delegate: SQLiteStatement,
+  private val logger: (String) -> Unit,
+) : SQLiteStatement by delegate {
+  private val bindings = mutableMapOf<Int, Any?>()
+  private var hasLogged = false
+
+  override fun bindBlob(index: Int, value: ByteArray) {
+    bindings[index] = "Blob(${value.size} bytes)"
+    delegate.bindBlob(index, value)
+  }
+
+  override fun bindDouble(index: Int, value: Double) {
+    bindings[index] = value
+    delegate.bindDouble(index, value)
+  }
+
+  override fun bindLong(index: Int, value: Long) {
+    bindings[index] = value
+    delegate.bindLong(index, value)
+  }
+
+  override fun bindText(index: Int, value: String) {
+    bindings[index] = value
+    delegate.bindText(index, value)
+  }
+
+  override fun bindNull(index: Int) {
+    bindings[index] = null
+    delegate.bindNull(index)
+  }
+
+  override fun bindBoolean(index: Int, value: Boolean) {
+    bindings[index] = value
+    delegate.bindBoolean(index, value)
+  }
+
+  override fun bindInt(index: Int, value: Int) {
+    bindings[index] = value
+    delegate.bindInt(index, value)
+  }
+
+  override fun bindFloat(index: Int, value: Float) {
+    bindings[index] = value
+    delegate.bindFloat(index, value)
+  }
+
+  override fun step(): Boolean {
+    if (!hasLogged) {
+      logger(formatLog(sql, bindings))
+      hasLogged = true
+    }
+    return delegate.step()
+  }
+
+  override fun reset() {
+    hasLogged = false
+    delegate.reset()
+  }
+
+  override fun clearBindings() {
+    bindings.clear()
+    delegate.clearBindings()
+  }
+}

--- a/stitch-runtime/src/jvmMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.jvm.kt
+++ b/stitch-runtime/src/jvmMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.jvm.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.SQLiteStatement
+
+internal actual class LoggingSQLiteDriver actual constructor(
+  private val delegate: SQLiteDriver,
+  private val logger: (String) -> Unit,
+) : SQLiteDriver by delegate {
+  override fun open(fileName: String): SQLiteConnection {
+    return LoggingSQLiteConnection(delegate.open(fileName), logger)
+  }
+}
+
+internal actual class LoggingSQLiteConnection actual constructor(
+  private val delegate: SQLiteConnection,
+  private val logger: (String) -> Unit,
+) : SQLiteConnection by delegate {
+  override fun prepare(sql: String): SQLiteStatement {
+    return LoggingSQLiteStatement(sql, delegate.prepare(sql), logger)
+  }
+}
+
+internal actual class LoggingSQLiteStatement actual constructor(
+  private val sql: String,
+  private val delegate: SQLiteStatement,
+  private val logger: (String) -> Unit,
+) : SQLiteStatement by delegate {
+  private val bindings = mutableMapOf<Int, Any?>()
+  private var hasLogged = false
+
+  override fun bindBlob(index: Int, value: ByteArray) {
+    bindings[index] = "Blob(${value.size} bytes)"
+    delegate.bindBlob(index, value)
+  }
+
+  override fun bindDouble(index: Int, value: Double) {
+    bindings[index] = value
+    delegate.bindDouble(index, value)
+  }
+
+  override fun bindLong(index: Int, value: Long) {
+    bindings[index] = value
+    delegate.bindLong(index, value)
+  }
+
+  override fun bindText(index: Int, value: String) {
+    bindings[index] = value
+    delegate.bindText(index, value)
+  }
+
+  override fun bindNull(index: Int) {
+    bindings[index] = null
+    delegate.bindNull(index)
+  }
+
+  override fun bindBoolean(index: Int, value: Boolean) {
+    bindings[index] = value
+    delegate.bindBoolean(index, value)
+  }
+
+  override fun bindInt(index: Int, value: Int) {
+    bindings[index] = value
+    delegate.bindInt(index, value)
+  }
+
+  override fun bindFloat(index: Int, value: Float) {
+    bindings[index] = value
+    delegate.bindFloat(index, value)
+  }
+
+  override fun step(): Boolean {
+    if (!hasLogged) {
+      logger(formatLog(sql, bindings))
+      hasLogged = true
+    }
+    return delegate.step()
+  }
+
+  override fun reset() {
+    hasLogged = false
+    delegate.reset()
+  }
+
+  override fun clearBindings() {
+    bindings.clear()
+    delegate.clearBindings()
+  }
+}

--- a/stitch-runtime/src/webMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.web.kt
+++ b/stitch-runtime/src/webMain/kotlin/dev/teogor/stitch/runtime/LoggingSQLiteDriver.web.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.stitch.runtime
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.SQLiteStatement
+
+internal actual class LoggingSQLiteDriver actual constructor(
+  private val delegate: SQLiteDriver,
+  private val logger: (String) -> Unit,
+) : SQLiteDriver by delegate {
+  override suspend fun open(fileName: String): SQLiteConnection {
+    return LoggingSQLiteConnection(delegate.open(fileName), logger)
+  }
+}
+
+internal actual class LoggingSQLiteConnection actual constructor(
+  private val delegate: SQLiteConnection,
+  private val logger: (String) -> Unit,
+) : SQLiteConnection by delegate {
+  override suspend fun prepare(sql: String): SQLiteStatement {
+    return LoggingSQLiteStatement(sql, delegate.prepare(sql), logger)
+  }
+}
+
+internal actual class LoggingSQLiteStatement actual constructor(
+  private val sql: String,
+  private val delegate: SQLiteStatement,
+  private val logger: (String) -> Unit,
+) : SQLiteStatement by delegate {
+  private val bindings = mutableMapOf<Int, Any?>()
+  private var hasLogged = false
+
+  override fun bindBlob(index: Int, value: ByteArray) {
+    bindings[index] = "Blob(${value.size} bytes)"
+    delegate.bindBlob(index, value)
+  }
+
+  override fun bindDouble(index: Int, value: Double) {
+    bindings[index] = value
+    delegate.bindDouble(index, value)
+  }
+
+  override fun bindLong(index: Int, value: Long) {
+    bindings[index] = value
+    delegate.bindLong(index, value)
+  }
+
+  override fun bindText(index: Int, value: String) {
+    bindings[index] = value
+    delegate.bindText(index, value)
+  }
+
+  override fun bindNull(index: Int) {
+    bindings[index] = null
+    delegate.bindNull(index)
+  }
+
+  override fun bindBoolean(index: Int, value: Boolean) {
+    bindings[index] = value
+    delegate.bindBoolean(index, value)
+  }
+
+  override fun bindInt(index: Int, value: Int) {
+    bindings[index] = value
+    delegate.bindInt(index, value)
+  }
+
+  override fun bindFloat(index: Int, value: Float) {
+    bindings[index] = value
+    delegate.bindFloat(index, value)
+  }
+
+  override suspend fun step(): Boolean {
+    if (!hasLogged) {
+      logger(formatLog(sql, bindings))
+      hasLogged = true
+    }
+    return delegate.step()
+  }
+
+  override fun reset() {
+    hasLogged = false
+    delegate.reset()
+  }
+
+  override fun clearBindings() {
+    bindings.clear()
+    delegate.clearBindings()
+  }
+}


### PR DESCRIPTION
Adds a `LoggingSQLiteDriver` that wraps any `SQLiteDriver` to provide visibility into executed SQL for debugging purposes.\n\nKey changes:\n- Implementation of `LoggingSQLiteDriver` and `LoggingSQLiteConnection` decorators in `stitch-runtime`.\n- Integration with `StitchRoomConfig` to allow easy enabling of logging via the DSL.\n\nThis enables developers to easily monitor and debug SQL queries being executed by the Room database.