### PR TITLE
Support Nullable and Optional Package Configurations in Stitch Gradle Plugin

### DIFF
--- a/stitch-common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
+++ b/stitch-common/src/commonMain/kotlin/dev/teogor/stitch/api/StitchExtension.kt
@@ -78,7 +78,7 @@ interface StitchExtension {
      *
      * @return The base package name for generated code.
      */
-    var generatedPackageName: String
+    var generatedPackageName: String?
 
     /**
      * The suffix to append to the generated repository interfaces.

--- a/stitch-gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
+++ b/stitch-gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchExtensionImpl.kt
@@ -74,7 +74,7 @@ abstract class StitchExtensionImpl : StitchExtension {
      * By default, this is an empty string, meaning the generated code will be
      * placed in the root package.
      */
-    override var generatedPackageName: String = ""
+    override var generatedPackageName: String? = null
 
     /**
      * The suffix to append to the generated repository interfaces.

--- a/stitch-gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
+++ b/stitch-gradle-plugin/src/main/kotlin/dev/teogor/stitch/StitchSchemaArgProvider.kt
@@ -25,7 +25,7 @@ import org.gradle.process.CommandLineArgumentProvider
 class StitchSchemaArgProvider(
     private val addDocumentation: Boolean,
     private val enableOperationGeneration: Boolean,
-    private val generatedPackageName: String,
+    private val generatedPackageName: String?,
     private val operationGenerationLevel: OperationGenerationLevel,
     private val repositorySuffix: String,
     private val operationSuffix: String,
@@ -43,25 +43,27 @@ class StitchSchemaArgProvider(
 ) : CommandLineArgumentProvider {
 
     override fun asArguments() = listOf(
-        "stitch.addDocumentation=$addDocumentation",
-        "stitch.enableOperationGeneration=$enableOperationGeneration",
-        "stitch.generatedPackageName=$generatedPackageName",
-        "stitch.operationGenerationLevel=$operationGenerationLevel",
-        "stitch.repositorySuffix=$repositorySuffix",
-        "stitch.operationSuffix=$operationSuffix",
-        "stitch.enableMetro=$enableMetro",
-        "stitch.diFramework=$diFramework",
-        "stitch.visibility=$visibility",
-        "stitch.enableRepositoryImplGeneration=$enableRepositoryImplGeneration",
-        "stitch.enableDatabaseBuilderGeneration=$enableDatabaseBuilderGeneration",
-    ) + listOfNotNull(
-        repositoryPackage?.let { "stitch.repositoryPackage=$it" },
-        repositoryImplPackage?.let { "stitch.repositoryImplPackage=$it" },
-        operationPackage?.let { "stitch.operationPackage=$it" },
-        diPackage?.let { "stitch.diPackage=$it" },
-        injectAnnotation?.let { "stitch.injectAnnotation=$it" },
-        repositoryBaseClass?.let { "stitch.repositoryBaseClass=$it" },
-    )
+        "stitch.addDocumentation" to addDocumentation,
+        "stitch.enableOperationGeneration" to enableOperationGeneration,
+        "stitch.generatedPackageName" to generatedPackageName,
+        "stitch.operationGenerationLevel" to operationGenerationLevel,
+        "stitch.repositorySuffix" to repositorySuffix,
+        "stitch.operationSuffix" to operationSuffix,
+        "stitch.enableMetro" to enableMetro,
+        "stitch.diFramework" to diFramework,
+        "stitch.visibility" to visibility,
+        "stitch.enableRepositoryImplGeneration" to enableRepositoryImplGeneration,
+        "stitch.enableDatabaseBuilderGeneration" to enableDatabaseBuilderGeneration,
+        "stitch.repositoryPackage" to repositoryPackage,
+        "stitch.repositoryImplPackage" to repositoryImplPackage,
+        "stitch.operationPackage" to operationPackage,
+        "stitch.diPackage" to diPackage,
+        "stitch.injectAnnotation" to injectAnnotation,
+        "stitch.repositoryBaseClass" to repositoryBaseClass,
+    ).mapNotNull { (key, value) ->
+        val valueStr = value?.toString()
+        if (!valueStr.isNullOrBlank()) "$key=$valueStr" else null
+    }
 
     companion object {
         @Suppress("DEPRECATION")


### PR DESCRIPTION
### Summary
This pull request updates the `StitchExtension` API and its internal argument provider to allow `generatedPackageName` to be nullable and completely optional. Additionally, it refactors the KSP compiler argument serialization to dynamically filter out null or blank configuration values, ensuring cleaner integration with the underlying symbol processor.

### Key Changes
- **API Refinement**: Modified `StitchExtension` to declare `generatedPackageName` as a nullable `String?` rather than a strict non-null type.
- **Default Value Update**: Adjusted `StitchExtensionImpl` to initialize `generatedPackageName` to `null` instead of an empty string (`""`).
- **Robust Argument Parsing**: Refactored `StitchSchemaArgProvider` to use a key-value pair map during serialization, ensuring that any blank or null properties are omitted instead of appended as malformed compiler arguments.
