### PR TITLE
Fix Implicit KSP Metadata Task Dependencies in Kotlin Multiplatform

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/KmpProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/dev/teogor/stitch/convention/KmpProjectExtensions.kt
@@ -129,9 +129,17 @@ fun Project.kspMultiplatform(
     // 3. Enforce safe build execution boundaries to protect against WorkValidationException
     tasks.configureEach {
         val taskName = name
-        if (!taskName.contains("Metadata") && taskName != "kspCommonMainKotlinMetadata") {
-            if (taskName.startsWith("ksp") || taskName.startsWith("compileKotlin")) {
-                dependsOn("kspCommonMainKotlinMetadata")
+        if (taskName != "kspCommonMainKotlinMetadata") {
+            val isKspTask = taskName.startsWith("ksp")
+            val isCompileTask = taskName.startsWith("compileKotlin")
+            val isSourcesJarTask = taskName.contains("SourcesJar", ignoreCase = true) || taskName == "sourcesJar"
+
+            if (isKspTask || isCompileTask || isSourcesJarTask) {
+                if (commonProcessors.isNotEmpty()) {
+                    runCatching {
+                        dependsOn("kspCommonMainKotlinMetadata")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary
Resolves Gradle `WorkValidationException` by explicitly declaring dependencies between KSP metadata generation and downstream compilation/source tasks in KMP modules.

### Key Changes
- **Task Wiring**: Updated `kspMultiplatform` to ensure `sourcesJar` and `compileKotlin` tasks correctly depend on `kspCommonMainKotlinMetadata`.
- **Improved Filtering**: Broadened task detection to include platform-specific source JAR variants (e.g., `androidSourcesJar`).
- **Build Safety**: Added `runCatching` to the dependency declaration to prevent failures in projects with partially applied KSP configurations.