### PR TITLE
Standardize Artifact Naming Across Stitch Modules

### DIFF
--- a/docs/assets/winds/stitch.json
+++ b/docs/assets/winds/stitch.json
@@ -1,0 +1,92 @@
+[
+  {
+    "module": "dev.teogor.stitch:stitch",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Alpha",
+      "versionQualifier": 2
+    },
+    "date": 1782432344,
+    "dependencies": [
+      {
+        "module": "dev.teogor.stitch:stitch-codegen",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-common",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-gradle-plugin",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-gradle-plugin-api",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-ksp",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-runtime",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      },
+      {
+        "module": "dev.teogor.stitch:stitch-web",
+        "version": {
+          "major": 1,
+          "minor": 0,
+          "patch": 0,
+          "flag": "Alpha",
+          "versionQualifier": 2
+        },
+        "date": 1782432344
+      }
+    ]
+  }
+]

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,85 @@
+# Stitch
+
+Learn more: **[User Guide](../user-guide.md)** and **[Code Samples](../code-samples.md)**
+
+🪡 Stitch handles the Room boilerplate, including automatic generation of repositories, dependency injection integration, and flexible customizations.
+
+[//]: # (REGION-API-REFERENCE)
+
+API Reference
+[`dev.teogor.stitch:stitch-*`](../)
+[`dev.teogor.stitch:stitch-codegen`](../stitch-codegen)
+[`dev.teogor.stitch:stitch-common`](../stitch-common)
+[`dev.teogor.stitch:stitch-gradle-plugin`](../stitch-gradle-plugin)
+[`dev.teogor.stitch:stitch-gradle-plugin-api`](../stitch-gradle-plugin-api)
+[`dev.teogor.stitch:stitch-ksp`](../stitch-ksp)
+[`dev.teogor.stitch:stitch-runtime`](../stitch-runtime)
+[`dev.teogor.stitch:stitch-web`](../stitch-web)
+
+[//]: # (REGION-API-REFERENCE)
+
+[//]: # (REGION-RELEASE-TABLE)
+
+| Latest Update   |  Stable Release  |  Release Candidate  |  Beta Release  |  Alpha Release  |
+|:----------------|:----------------:|:-------------------:|:--------------:|:---------------:|
+| June 26, 2026   |        -         |          -          |       -        |  1.0.0-alpha02  |
+
+[//]: # (REGION-RELEASE-TABLE)
+
+[//]: # (REGION-DEPENDENCIES)
+
+## Declaring dependencies
+
+To use Stitch in your app, add the following dependencies to your app's `build.gradle` file:
+
+=== "Groovy"
+
+    ```groovy title="build.gradle"
+    dependencies {
+        def teogorStitch = "1.0.0-alpha02"
+
+        implementation "dev.teogor.stitch:stitch-codegen:$teogorStitch"
+        implementation "dev.teogor.stitch:stitch-common:$teogorStitch"
+        implementation "dev.teogor.stitch:stitch-gradle-plugin-api:$teogorStitch"
+        implementation "dev.teogor.stitch:stitch-ksp:$teogorStitch"
+        implementation "dev.teogor.stitch:stitch-runtime:$teogorStitch"
+        implementation "dev.teogor.stitch:stitch-web:$teogorStitch"
+    }
+    ```
+
+=== "Kotlin"
+
+    ```kotlin title="build.gradle.kts"
+    dependencies {
+        val teogorStitch = "1.0.0-alpha02"
+
+        implementation("dev.teogor.stitch:stitch-codegen:$teogorStitch")
+        implementation("dev.teogor.stitch:stitch-common:$teogorStitch")
+        implementation("dev.teogor.stitch:stitch-gradle-plugin-api:$teogorStitch")
+        implementation("dev.teogor.stitch:stitch-ksp:$teogorStitch")
+        implementation("dev.teogor.stitch:stitch-runtime:$teogorStitch")
+        implementation("dev.teogor.stitch:stitch-web:$teogorStitch")
+    }
+    ```
+
+For comprehensive instructions on adding these dependencies, refer to the [Stitch documentation](../index.md#getting-started-with-stitch).
+
+[//]: # (REGION-DEPENDENCIES)
+
+[//]: # (REGION-FEEDBACK)
+
+## Feedback
+
+Your feedback helps make Stitch better. Let us know if you discover new issues or have
+ideas for improving this library. Please take a look at the [existing issues on GitHub](https://github.com/teogor/stitch/issues)
+for this library before you create a new one.
+
+[Create a new issue](https://github.com/teogor/stitch/issues/new){ .md-button }
+
+[//]: # (REGION-FEEDBACK)
+
+[//]: # (REGION-VERSION-CHANGELOG)
+
+
+
+[//]: # (REGION-VERSION-CHANGELOG)

--- a/stitch-codegen/build.gradle.kts
+++ b/stitch-codegen/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-codegen"
+            name = "codegen"
         }
     }
 }

--- a/stitch-common/build.gradle.kts
+++ b/stitch-common/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-common"
+            name = "common"
         }
     }
 }

--- a/stitch-gradle-plugin-api/build.gradle.kts
+++ b/stitch-gradle-plugin-api/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-gradle-plugin-api"
+            name = "gradle-plugin-api"
         }
     }
 }

--- a/stitch-gradle-plugin/build.gradle.kts
+++ b/stitch-gradle-plugin/build.gradle.kts
@@ -49,7 +49,7 @@ gradlePlugin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-gradle-plugin"
+            name = "gradle-plugin"
         }
     }
 }

--- a/stitch-ksp/build.gradle.kts
+++ b/stitch-ksp/build.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-ksp"
+            name = "ksp"
         }
     }
 }

--- a/stitch-runtime/build.gradle.kts
+++ b/stitch-runtime/build.gradle.kts
@@ -90,7 +90,7 @@ kotlin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-runtime"
+            name = "runtime"
         }
     }
 }

--- a/stitch-web/build.gradle.kts
+++ b/stitch-web/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 winds {
     moduleMetadata {
         artifactDescriptor {
-            name = "stitch-web"
+            name = "web"
         }
     }
 }


### PR DESCRIPTION
### Summary
This PR standardizes the artifact naming convention by removing the redundant `stitch-` prefix from the `winds` artifact descriptors across all sub-projects. It also updates the documentation and Winds metadata to reflect these changes, ensuring consistency between the build configuration and the published documentation.

### Key Changes
- **Build Configuration**: Removed `stitch-` prefix from `artifactDescriptor.name` in all `build.gradle.kts` files (e.g., `stitch-common` becomes `common`).
- **Winds Metadata**: Updated `docs/assets/winds/stitch.json` with the new standardized module identifiers.
- **Documentation**:
    - Updated `docs/releases/index.md` and `docs/releases/implementation.md` to use the shortened artifact IDs in dependency snippets and API references.
    - Synchronized Version Catalog examples to match the updated naming scheme.